### PR TITLE
Fix compilation with `-with-64bit-coord`

### DIFF
--- a/src/tl/tl/tlString.cc
+++ b/src/tl/tl/tlString.cc
@@ -231,6 +231,32 @@ tl::to_string (const unsigned long long &d)
   return os.str ();
 }
 
+#if defined(HAVE_64BIT_COORD)
+template <>
+std::string
+tl::to_string (const __int128 &d)
+{
+  if (d < 0 ) {
+    return "-" + tl::to_string(static_cast<unsigned __int128>(-d));
+  } else {
+    return tl::to_string(static_cast<unsigned __int128>(d));
+  }
+}
+
+template <>
+std::string
+tl::to_string (const unsigned __int128 &d)
+{
+  if (static_cast<uint64_t>(d) == d) {
+    return tl::to_string(static_cast<uint64_t>(d));
+  }
+  std::ostringstream os;
+  os.imbue (c_locale);
+  os << "0x" << std::hex << static_cast<uint64_t> (d>>64) << static_cast<uint64_t> (d);  
+  return os.str ();
+}
+#endif
+
 template <>
 std::string
 tl::to_string (char * const &cp)

--- a/src/tl/tl/tlString.h
+++ b/src/tl/tl/tlString.h
@@ -271,6 +271,10 @@ template <> TL_PUBLIC std::string to_string (const long &d);
 template <> TL_PUBLIC std::string to_string (const unsigned long &d);
 template <> TL_PUBLIC std::string to_string (const long long &d);
 template <> TL_PUBLIC std::string to_string (const unsigned long long &d);
+#if defined(HAVE_64BIT_COORD)
+template <> TL_PUBLIC std::string to_string (const __int128 &d);
+template <> TL_PUBLIC std::string to_string (const unsigned __int128 &d);
+#endif
 template <> TL_PUBLIC std::string to_string (const char * const &cp);
 template <> TL_PUBLIC std::string to_string (char * const &cp);
 template <> TL_PUBLIC std::string to_string (const unsigned char * const &cp);

--- a/src/tl/tl/tlVariant.cc
+++ b/src/tl/tl/tlVariant.cc
@@ -2189,7 +2189,7 @@ QVariant Variant::to_qvariant () const
 #if defined(HAVE_64BIT_COORD)
   case t_int128:
     //  TODO: support for int128 in QVariant?
-    return QVariant ((double) m_var.m_m128);
+    return QVariant ((double) m_var.m_int128);
 #endif
   case t_bool:
     return QVariant (m_var.m_bool);


### PR DESCRIPTION
`src/db/unit_tests` still do not compile so need to fix it or temporarily remove it
from `src/db/db.pro` to make klayout compile with the experimental 64bit coordinate support.