### PR TITLE
Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-language: python
-python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.6"
-  - "3.7" 
-
 matrix:
   include:
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
+      language: python
+      python:
+        - "3.3"
+        - "3.4"
+        - "3.5"
+        - "3.6"
+        - "3.6"
+        - "3.7" 
       env:
         - MATRIX_EVAL=""
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ os: osx
 matrix:
   include:
   - osx_image: xcode9.3
-  env:
-    - MATRIX_EVAL=""
+    env:
+      - MATRIX_EVAL=""
   - osx_image: xcode8.3
-  env:
-    - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
+    env:
+      - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
   - osx_image: xcode7.3
-  env:
-    - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
+    env:
+      - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
 
 before_install:
   - rvm install 2.2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - python3 setup.py build
   - python3 setup.py bdist_wheel
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py install; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python3 setup.py installs; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python3 setup.py install; fi
 
 script:
   - python3 -c 'import klayout.db as db; print(dir(db))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - rvm install ruby --latest
   - gem install dropbox-deployment
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python3-setuptools; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip install wheel; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,35 @@
-os: osx
-
 matrix:
   include:
-  - osx_image: xcode9.3  # macOS 10.13
-    env:
-      - MATRIX_EVAL=""
-  - osx_image: xcode8.3  # macOS 10.12
-    env:
-      - MATRIX_EVAL=""
-  - osx_image: xcode8  # macOS 10.11
-    env:
-      - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+    - osx_image: xcode9.3  # macOS 10.13
+      env:
+        - MATRIX_EVAL=""
+    - osx_image: xcode8.3  # macOS 10.12
+      env:
+        - MATRIX_EVAL=""
+    - osx_image: xcode8  # macOS 10.11
+      env:
+        - MATRIX_EVAL=""
 
 before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - brew update
-  - brew bundle
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
   - eval "${MATRIX_EVAL}"
 
 install:
   - python3 setup.py build
   - python3 setup.py install
   - python3 setup.py bdist_wheel
+
 script:
   - python3 -c 'import klayout.db as db; print(dir(db))'
   - python3 -c 'import klayout.rdb as rdb; print(dir(rdb))'
   - python3 -c 'import klayout.tl as tl; print(dir(tl))'
+
 after_success:
   - dropbox-deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install --user setuptools; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install --user setuptools; fi
   - python3 setup.py build
   - python3 setup.py install
   - python3 setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,14 @@ matrix:
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
+      language: python
       python: '3.6'
       env:
         - MATRIX_EVAL=""
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
+      language: python
       python: '3.7'
       env:
         - MATRIX_EVAL=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ os: osx
 
 matrix:
   include:
-  - osx_image: xcode9.3
+  - osx_image: xcode9.3  # macOS 10.13
     env:
       - MATRIX_EVAL=""
-  - osx_image: xcode8.3
+  - osx_image: xcode8.3  # macOS 10.12
     env:
-      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc && export CXX=g++"
-  - osx_image: xcode7.3
+      - MATRIX_EVAL=""
+  - osx_image: xcode7.3  # macOS 10.11
     env:
-      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc && export CXX=g++"
+      - MATRIX_EVAL=""
 
 before_install:
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; else pip install sysconfig; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; fi
   - eval "${MATRIX_EVAL}"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; fi
   - eval "${MATRIX_EVAL}"
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
+language: python
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.6"
+  - "3.7" 
+
 matrix:
   include:
     - os: linux
       dist: trusty # Ubuntu 14.04
-      sudo: true
+      sudo: false
       env:
         - MATRIX_EVAL=""
     - os: osx
@@ -22,21 +31,21 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python3-setuptools python3-wheel; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install setuptools wheel; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
   - eval "${MATRIX_EVAL}"
 
 install:
-  - python3 setup.py build
-  - python3 setup.py bdist_wheel
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py install; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python3 setup.py install; fi
+  - python setup.py build
+  - python setup.py bdist_wheel
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python setup.py install; fi
 
 script:
-  - python3 -c 'import klayout.db as db; print(dir(db))'
-  - python3 -c 'import klayout.rdb as rdb; print(dir(rdb))'
-  - python3 -c 'import klayout.tl as tl; print(dir(tl))'
+  - python -c 'import klayout.db as db; print(dir(db))'
+  - python -c 'import klayout.rdb as rdb; print(dir(rdb))'
+  - python -c 'import klayout.tl as tl; print(dir(tl))'
 
 after_success:
   - dropbox-deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 before_install:
   - env
-  - rvm install 2.2.6
+  - rvm install ruby --latest
   - gem install dropbox-deployment
   - brew update
   - brew bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ before_install:
   - gem install dropbox-deployment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; fi
   - eval "${MATRIX_EVAL}"
+  - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,6 @@ matrix:
       python: '3.6'
       env:
         - MATRIX_EVAL=""
-    - os: linux
-      dist: trusty # Ubuntu 14.04
-      sudo: false
-      language: python
-      python: '3.7'
-      env:
-        - MATRIX_EVAL=""
     - os: osx
       osx_image: xcode9.3  # macOS 10.13
       env:
@@ -66,7 +59,7 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; else pip install sysconfig; fi
   - eval "${MATRIX_EVAL}"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,21 @@ os: osx
 matrix:
   include:
   - osx_image: xcode9.3
+  env:
+    - MATRIX_EVAL=""
   - osx_image: xcode8.3
+  env:
+    - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
   - osx_image: xcode7.3
+  env:
+    - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
 
 before_install:
   - rvm install 2.2.6
   - gem install dropbox-deployment
   - brew update
   - brew bundle
+  - eval "${MATRIX_EVAL}"
   - env
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,47 @@ matrix:
       dist: trusty # Ubuntu 14.04
       sudo: false
       language: python
-      python:
-        - "3.3"
-        - "3.4"
-        - "3.5"
-        - "3.6"
-        - "3.6"
-        - "3.7" 
+      python: '2.6'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '2.7'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '3.3'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '3.4'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '3.5'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      python: '3.6'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      python: '3.7'
       env:
         - MATRIX_EVAL=""
     - os: osx
@@ -30,16 +64,13 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install setuptools wheel; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; alias python='python3'; fi
   - eval "${MATRIX_EVAL}"
 
 install:
   - python setup.py build
   - python setup.py bdist_wheel
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py install; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python setup.py install; fi
+  - python setup.py install
 
 script:
   - python -c 'import klayout.db as db; print(dir(db))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - os: linux
       dist: trusty # Ubuntu 14.04
-      sudo: false
+      sudo: true
       env:
         - MATRIX_EVAL=""
     - os: osx
@@ -22,12 +22,12 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python3-setuptools; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
   - eval "${MATRIX_EVAL}"
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install --user setuptools; fi
   - python3 setup.py build
   - python3 setup.py install
   - python3 setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ matrix:
       - MATRIX_EVAL=""
   - osx_image: xcode8.3
     env:
-      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc-7 && export CXX=g++-7"
+      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc && export CXX=g++"
   - osx_image: xcode7.3
     env:
-      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc-7 && export CXX=g++-7"
+      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc && export CXX=g++"
 
 before_install:
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,18 @@ matrix:
       - MATRIX_EVAL=""
   - osx_image: xcode8.3
     env:
-      - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
+      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc-7 && export CXX=g++-7"
   - osx_image: xcode7.3
     env:
-      - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
+      - MATRIX_EVAL="brew install gcc || brew link --overwrite gcc; export CC=gcc-7 && export CXX=g++-7"
 
 before_install:
+  - env
   - rvm install 2.2.6
   - gem install dropbox-deployment
   - brew update
   - brew bundle
   - eval "${MATRIX_EVAL}"
-  - env
 
 install:
   - python3 setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ before_install:
 
 install:
   - python3 setup.py build
-  - python3 setup.py install
   - python3 setup.py bdist_wheel
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 setup.py install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo python3 setup.py installs; fi
 
 script:
   - python3 -c 'import klayout.db as db; print(dir(db))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,18 @@ matrix:
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
-    - osx_image: xcode9.3  # macOS 10.13
       env:
         - MATRIX_EVAL=""
-    - osx_image: xcode8.3  # macOS 10.12
+    - os: osx
+      osx_image: xcode9.3  # macOS 10.13
       env:
         - MATRIX_EVAL=""
-    - osx_image: xcode8  # macOS 10.11
+    - os: osx
+      osx_image: xcode8.3  # macOS 10.12
+      env:
+        - MATRIX_EVAL=""
+    - os: osx
+      osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python3-setuptools; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip install wheel; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python3-setuptools python3-wheel; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
+os: osx
+
 matrix:
   include:
-  - os: osx
-    osx_image: xcode9.3beta
-    env:
-    - MATRIX_EVAL=""
+  - osx_image: xcode9.3
+  - osx_image: xcode8.3
+  - osx_image: xcode7.3
 
 before_install:
-  - eval "${MATRIX_EVAL}"
+  - rvm install 2.2.6
+  - gem install dropbox-deployment
   - brew update
   - brew bundle
   - env
 
 install:
+  - python3 setup.py build
   - python3 setup.py install
+  - python3 setup.py bdist_wheel
 script:
   - python3 -c 'import klayout.db as db; print(dir(db))'
   - python3 -c 'import klayout.rdb as rdb; print(dir(rdb))'
   - python3 -c 'import klayout.tl as tl; print(dir(tl))'
+after_success:
+  - dropbox-deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
 
 install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install --user setuptools; fi
   - python3 setup.py build
   - python3 setup.py install
   - python3 setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   - osx_image: xcode8.3  # macOS 10.12
     env:
       - MATRIX_EVAL=""
-  - osx_image: xcode7.3  # macOS 10.11
+  - osx_image: xcode8  # macOS 10.11
     env:
       - MATRIX_EVAL=""
 

--- a/dropbox-deployment.yml
+++ b/dropbox-deployment.yml
@@ -1,0 +1,4 @@
+deploy:
+  dropbox_path: /Builds/klayout-pymod # The path to the folder on Dropbox where the files will go
+  artifacts_path: dist # can be a single file, or a path
+  debug: true # if you want to see more logs

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ from setuptools import setup, Extension, Distribution
 import glob
 import os
 import platform
-import sysconfig
+import distutils.sysconfig as sysconfig
 
 # ----------------------------------------------------------------------------------------
 
@@ -85,6 +85,7 @@ class Config(object):
         Returns the library name for a given module
         The library name is usually decorated (i.e. "tl" -> "tl.cpython-35m-x86_64-linux-gnu.so").
         """
+        print 
         return mod + self.ext_suffix
 
     def path_of(self, mod):

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ class Config(object):
 
         self.ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
         if self.ext_suffix is None:
-            self.ext_suffix = ""
-            
+            self.ext_suffix = ".so"
+
         self.root = "klayout"
 
     def libname_of(self, mod):

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ class Config(object):
         self.build_platlib = build_cmd.build_platlib
 
         self.ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+        if self.ext_suffix is None:
+            self.ext_suffix = ""
+            
         self.root = "klayout"
 
     def libname_of(self, mod):
@@ -85,7 +88,6 @@ class Config(object):
         Returns the library name for a given module
         The library name is usually decorated (i.e. "tl" -> "tl.cpython-35m-x86_64-linux-gnu.so").
         """
-        print 
         return mod + self.ext_suffix
 
     def path_of(self, mod):

--- a/src/tl/tl/tlLog.cc
+++ b/src/tl/tl/tlLog.cc
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #if defined(_WIN32)
 #  include <windows.h>
@@ -64,13 +65,13 @@ static int default_verbosity ()
 
 static int m_verbosity_level = default_verbosity ();
 
-void 
+void
 verbosity (int level)
 {
   m_verbosity_level = level;
 }
 
-int 
+int
 verbosity ()
 {
   return m_verbosity_level;
@@ -79,7 +80,7 @@ verbosity ()
 // ------------------------------------------------
 //  Channel implementation
 
-Channel::Channel () 
+Channel::Channel ()
   : m_no_endl (false), m_active (false)
 {
   //  .. nothing else ..
@@ -90,7 +91,7 @@ Channel::~Channel ()
   // .. nothing yet ..
 }
 
-ChannelProxy 
+ChannelProxy
 Channel::issue_proxy ()
 {
   m_no_endl = false;
@@ -102,7 +103,7 @@ Channel::issue_proxy ()
   return ChannelProxy (this);
 }
 
-void 
+void
 Channel::release_proxy ()
 {
   if (! m_no_endl) {
@@ -130,7 +131,7 @@ LogTee::LogTee (Channel *first, bool owned)
   add (first, owned);
 }
 
-void 
+void
 LogTee::add (Channel *other, bool owned)
 {
   m_lock.lock ();
@@ -161,7 +162,7 @@ LogTee::clear ()
   m_lock.unlock ();
 }
 
-void 
+void
 LogTee::puts (const char *s)
 {
   try {
@@ -173,7 +174,7 @@ LogTee::puts (const char *s)
   }
 }
 
-void 
+void
 LogTee::endl ()
 {
   try {
@@ -185,7 +186,7 @@ LogTee::endl ()
   }
 }
 
-void 
+void
 LogTee::end ()
 {
   try {
@@ -197,7 +198,7 @@ LogTee::end ()
   }
 }
 
-void 
+void
 LogTee::begin ()
 {
   try {
@@ -292,7 +293,7 @@ InfoChannel::~InfoChannel ()
   //  .. nothing yet ..
 }
 
-void 
+void
 InfoChannel::puts (const char *s)
 {
   if (verbosity () >= m_verbosity) {
@@ -300,7 +301,7 @@ InfoChannel::puts (const char *s)
   }
 }
 
-void 
+void
 InfoChannel::endl ()
 {
   if (verbosity () >= m_verbosity) {
@@ -308,7 +309,7 @@ InfoChannel::endl ()
   }
 }
 
-void 
+void
 InfoChannel::end ()
 {
   if (verbosity () >= m_verbosity) {
@@ -319,7 +320,7 @@ InfoChannel::end ()
   }
 }
 
-void 
+void
 InfoChannel::begin ()
 {
   if (verbosity () >= m_verbosity) {
@@ -362,19 +363,19 @@ WarningChannel::~WarningChannel ()
   //  .. nothing yet ..
 }
 
-void 
+void
 WarningChannel::puts (const char *s)
 {
   fputs (s, stdout);
 }
 
-void 
+void
 WarningChannel::endl ()
 {
   fputs ("\n", stdout);
 }
 
-void 
+void
 WarningChannel::end ()
 {
   if (m_colorized) {
@@ -383,7 +384,7 @@ WarningChannel::end ()
   fflush (stdout);
 }
 
-void 
+void
 WarningChannel::begin ()
 {
   if (m_colorized) {
@@ -426,19 +427,19 @@ ErrorChannel::~ErrorChannel ()
   //  .. nothing yet ..
 }
 
-void 
+void
 ErrorChannel::puts (const char *s)
 {
   fputs (s, stderr);
 }
 
-void 
+void
 ErrorChannel::endl ()
 {
   fputs ("\n", stderr);
 }
 
-void 
+void
 ErrorChannel::end ()
 {
   if (m_colorized) {
@@ -447,7 +448,7 @@ ErrorChannel::end ()
   fflush (stderr);
 }
 
-void 
+void
 ErrorChannel::begin ()
 {
   if (m_colorized) {

--- a/src/tl/tl/tlThreads.cc
+++ b/src/tl/tl/tlThreads.cc
@@ -23,44 +23,21 @@
 #if !defined(HAVE_QT)
 
 #include "tlThreads.h"
+#include "tlUtils.h"
 #include "tlLog.h"
 #include "tlInternational.h"
 
 #include <map>
 #include <pthread.h>
-#include <time.h>
 #include <errno.h>
 #include <unistd.h>
 #if defined(_WIN32)
 #  include <windows.h>
 #endif
-#if defined(__MACH__)
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
 
 namespace tl
 {
 
-// -------------------------------------------------------------------------------
-//  clock_gettime is not implemented in Mac OS X 10.11 and lower
-//  From: https://gist.githubusercontent.com/jbenet/1087739/raw/638b37f76cdd9dc46d617443cab27eac297e2ee3/current_utc_time.c
-
-void current_utc_time(struct timespec *ts) {
-
-#if defined(__MACH__)
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  ts->tv_sec = mts.tv_sec;
-  ts->tv_nsec = mts.tv_nsec;
-#else
-  clock_gettime(CLOCK_REALTIME, ts);
-#endif
-
-}
 // -------------------------------------------------------------------------------
 //  WaitCondition implementation
 

--- a/src/tl/tl/tlThreads.cc
+++ b/src/tl/tl/tlThreads.cc
@@ -34,10 +34,33 @@
 #if defined(_WIN32)
 #  include <windows.h>
 #endif
+#if defined(__MACH__)
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
 
 namespace tl
 {
 
+// -------------------------------------------------------------------------------
+//  clock_gettime is not implemented in Mac OS X 10.11 and lower
+//  From: https://gist.githubusercontent.com/jbenet/1087739/raw/638b37f76cdd9dc46d617443cab27eac297e2ee3/current_utc_time.c
+
+void current_utc_time(struct timespec *ts) {
+
+#if defined(__MACH__)
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts->tv_sec = mts.tv_sec;
+  ts->tv_nsec = mts.tv_nsec;
+#else
+  clock_gettime(CLOCK_REALTIME, ts);
+#endif
+
+}
 // -------------------------------------------------------------------------------
 //  WaitCondition implementation
 
@@ -270,7 +293,7 @@ bool Thread::wait (unsigned long time)
   if (time < std::numeric_limits<unsigned long>::max ()) {
 
     struct timespec end_time;
-    clock_gettime (CLOCK_REALTIME, &end_time);
+    current_utc_time (&end_time);
 
     end_time.tv_sec += (time / 1000);
     end_time.tv_nsec += (time % 1000) * 1000000;

--- a/src/tl/tl/tlThreads.cc
+++ b/src/tl/tl/tlThreads.cc
@@ -105,7 +105,7 @@ public:
     if (time < std::numeric_limits<unsigned long>::max ()) {
 
       struct timespec end_time;
-      clock_gettime (CLOCK_REALTIME, &end_time);
+      current_utc_time (&end_time);
 
       end_time.tv_sec += (time / 1000);
       end_time.tv_nsec += (time % 1000) * 1000000;
@@ -308,7 +308,7 @@ bool Thread::wait (unsigned long time)
     while (isRunning ()) {
 
       struct timespec current_time;
-      clock_gettime (CLOCK_REALTIME, &current_time);
+      current_utc_time (&current_time);
       if (end_time.tv_sec < current_time.tv_sec || (end_time.tv_sec == current_time.tv_sec && end_time.tv_nsec < current_time.tv_nsec)) {
         return false;
       }

--- a/src/tl/tl/tlTimer.cc
+++ b/src/tl/tl/tlTimer.cc
@@ -22,6 +22,7 @@
 
 
 #include "tlTimer.h"
+#include "tlUtils.h"
 #include "tlLog.h"
 #include "tlString.h"
 
@@ -30,7 +31,6 @@
 #endif
 
 #include <stdio.h>
-#include <time.h>
 
 #ifndef _MSC_VER // not available on MS VC++
 #  include <unistd.h>
@@ -45,7 +45,7 @@ namespace tl
 static int64_t ms_time ()
 {
   struct timespec spec;
-  clock_gettime (CLOCK_REALTIME, &spec);
+  current_utc_time (&spec);
 
   return int64_t (spec.tv_sec) * 1000 + int64_t (0.5 + spec.tv_nsec / 1.0e6);
 }
@@ -77,7 +77,7 @@ Timer::start ()
 #endif
 
   struct timespec spec;
-  clock_gettime (CLOCK_REALTIME, &spec);
+  current_utc_time (&spec);
 
   m_wall_ms += ms_time ();
 }

--- a/src/tl/tl/tlUtils.h
+++ b/src/tl/tl/tlUtils.h
@@ -27,9 +27,36 @@
 #include "tlAssert.h"
 
 #include <map>
+#include <time.h>
+
+#if defined(__MACH__)
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
 
 namespace tl
 {
+
+/**
+*  @brief clock_gettime is not implemented in Mac OS X 10.11 and lower
+*  From: https://gist.githubusercontent.com/jbenet/1087739/raw/638b37f76cdd9dc46d617443cab27eac297e2ee3/current_utc_time.c
+*/
+
+inline void current_utc_time(struct timespec *ts) {
+
+#if defined(__MACH__)
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts->tv_sec = mts.tv_sec;
+  ts->tv_nsec = mts.tv_nsec;
+#else
+  clock_gettime(CLOCK_REALTIME, ts);
+#endif
+
+}
 
 /**
  *  @brief A template class mapping a begin .. end iterator pair to the at_end semantics


### PR DESCRIPTION
- Ubuntu builds are added to travis.yml (Python 2.6, 2.7, 3.3, 3.4, 3.5, and 3.6)
- macOS 10.12 and macOS 10.11 are added to travis.yml
- Uses `distutils.sysconfig` instead of `sysconfig` to add support for Python 2
- Sets ext_suffix to ".so" if it is null
- Uses a different method to get the time because `clock_gettime` is not implemented in macOS 10.11 and lower