### PR TITLE
Extending db and improving setup.py & travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
+  - pip --version
+  - pip install --upgrade pip
+  - pip --version
+  - pip install --upgrade setuptools wheel
   - eval "${MATRIX_EVAL}"
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,17 @@ matrix:
       osx_image: xcode9.3  # macOS 10.13
       env:
         - MATRIX_EVAL=""
+        - ARCHFLAGS="-std=c++11"
     - os: osx
       osx_image: xcode8.3  # macOS 10.12
       env:
         - MATRIX_EVAL=""
+        - ARCHFLAGS="-std=c++11"
     - os: osx
       osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL=""
+        - ARCHFLAGS="-std=c++11"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
 matrix:
   include:
+    - os: osx
+      osx_image: xcode9.3  # macOS 10.13
+      env:
+        - MATRIX_EVAL=""
+    - os: osx
+      osx_image: xcode8.3  # macOS 10.12
+      env:
+        - MATRIX_EVAL=""
+    - os: osx
+      osx_image: xcode8  # macOS 10.11
+      env:
+        - MATRIX_EVAL=""
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
       language: python
-      python: '2.6'
+      python: '3.6'
       env:
         - MATRIX_EVAL=""
     - os: linux
@@ -12,6 +24,13 @@ matrix:
       sudo: false
       language: python
       python: '2.7'
+      env:
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '2.6'
       env:
         - MATRIX_EVAL=""
     - os: linux
@@ -33,25 +52,6 @@ matrix:
       sudo: false
       language: python
       python: '3.5'
-      env:
-        - MATRIX_EVAL=""
-    - os: linux
-      dist: trusty # Ubuntu 14.04
-      sudo: false
-      language: python
-      python: '3.6'
-      env:
-        - MATRIX_EVAL=""
-    - os: osx
-      osx_image: xcode9.3  # macOS 10.13
-      env:
-        - MATRIX_EVAL=""
-    - os: osx
-      osx_image: xcode8.3  # macOS 10.12
-      env:
-        - MATRIX_EVAL=""
-    - os: osx
-      osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - os: osx
       osx_image: xcode8.3  # macOS 10.12
       env:
-        - MATRIX_EVAL=""
+        - MATRIX_EVAL="brew install python2 || brew link --overwrite python@2"  # deficient python2 in travis's xcode8.3 (no ssl)
         - ARCHFLAGS="-std=c++11"
     - os: osx
       osx_image: xcode8  # macOS 10.11
@@ -80,11 +80,10 @@ before_install:
   - rvm install ruby --latest
   - gem install dropbox-deployment
   - eval "${MATRIX_EVAL}"
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -x "$(command -v pip)" ]]; then sudo easy_install pip; fi
   - pip --version
   - sudo pip install --upgrade pip
   - pip --version
-  - pip install --upgrade setuptools wheel
+  - sudo pip install --upgrade setuptools wheel
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -x "$(command -v pip)" ]]; then sudo easy_install pip; fi
   - pip --version
-  - pip install --upgrade pip
+  - sudo pip install --upgrade pip
   - pip --version
   - pip install --upgrade setuptools wheel
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 matrix:
   include:
+    # python 3 osx
     - os: osx
-      osx_image: xcode9.3  # macOS 10.13
+      osx_image: xcode9.4  # macOS 10.13
       env:
         - MATRIX_EVAL=""
         - ARCHFLAGS="-std=c++11"
@@ -14,6 +15,22 @@ matrix:
       osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL=""
+        - ARCHFLAGS="-std=c++11"
+    # python 2 osx
+    - os: osx
+      osx_image: xcode9.4  # macOS 10.13
+      env:
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
+        - ARCHFLAGS="-std=c++11"
+    - os: osx
+      osx_image: xcode8.3  # macOS 10.12
+      env:
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
+        - ARCHFLAGS="-std=c++11"
+    - os: osx
+      osx_image: xcode8  # macOS 10.11
+      env:
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
         - ARCHFLAGS="-std=c++11"
     - os: linux
       dist: trusty # Ubuntu 14.04
@@ -62,7 +79,6 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; fi
   - eval "${MATRIX_EVAL}"
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,17 @@ matrix:
     - os: osx
       osx_image: xcode9.4  # macOS 10.13
       env:
-        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
     - os: osx
       osx_image: xcode8.3  # macOS 10.12
       env:
-        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
     - os: osx
       osx_image: xcode8  # macOS 10.11
       env:
-        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3';"
+        - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
     - os: linux
       dist: trusty # Ubuntu 14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,32 +6,38 @@ matrix:
       env:
         - MATRIX_EVAL=""
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     - os: osx
       osx_image: xcode8.3  # macOS 10.12
       env:
         - MATRIX_EVAL="brew install python2 || brew link --overwrite python@2"  # deficient python2 in travis's xcode8.3 (no ssl)
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     - os: osx
       osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL=""
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     # python 2 osx
     - os: osx
       osx_image: xcode9.4  # macOS 10.13
       env:
         - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     - os: osx
       osx_image: xcode8.3  # macOS 10.12
       env:
         - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     - os: osx
       osx_image: xcode8  # macOS 10.11
       env:
         - MATRIX_EVAL="brew update; brew bundle; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
         - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -39,6 +45,7 @@ matrix:
       python: '3.6'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -46,6 +53,7 @@ matrix:
       python: '2.7'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -53,6 +61,7 @@ matrix:
       python: '2.6'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="0"  # setuptools installed from last pip has syntax error on py 2.6
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -60,6 +69,7 @@ matrix:
       python: '3.3'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -67,6 +77,7 @@ matrix:
       python: '3.4'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
     - os: linux
       dist: trusty # Ubuntu 14.04
       sudo: false
@@ -74,16 +85,19 @@ matrix:
       python: '3.5'
       env:
         - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
 
 before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
   - eval "${MATRIX_EVAL}"
-  - pip --version
-  - pip install --upgrade pip || sudo pip install --upgrade pip
-  - pip --version
-  - pip install --upgrade setuptools wheel || sudo pip install --upgrade setuptools wheel
+  - if [ "${PIP_UPDATE}" == "1" ]; then
+        pip --version;
+        pip install --upgrade pip || sudo pip install --upgrade pip;
+        pip --version;
+        pip install --upgrade setuptools wheel || sudo pip install --upgrade setuptools wheel;
+    fi
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,9 @@ before_install:
   - gem install dropbox-deployment
   - eval "${MATRIX_EVAL}"
   - pip --version
-  - sudo pip install --upgrade pip
+  - pip install --upgrade pip || sudo pip install --upgrade pip
   - pip --version
-  - sudo pip install --upgrade setuptools wheel
+  - pip install --upgrade setuptools wheel || sudo pip install --upgrade setuptools wheel
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,11 +79,12 @@ before_install:
   - env
   - rvm install ruby --latest
   - gem install dropbox-deployment
+  - eval "${MATRIX_EVAL}"
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -x "$(command -v pip)" ]]; then sudo easy_install pip; fi
   - pip --version
   - pip install --upgrade pip
   - pip --version
   - pip install --upgrade setuptools wheel
-  - eval "${MATRIX_EVAL}"
   - python -c "import distutils.sysconfig as sysconfig; print(sysconfig.__file__)"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,9 @@ def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=N
     macros, objects, extra_postargs, pp_opts, build = self._setup_compile(output_dir, macros, include_dirs, sources, depends, extra_postargs)
     cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
     # parallel code
-    N=2 # number of parallel compilations
+    import multiprocessing
+
+    N = multiprocessing.cpu_count() # number of parallel compilations
     import multiprocessing.pool
     def _single_compile(obj):
         try: src, ext = build[obj]

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=N
 
 # only if python version > 2.6, somehow the travis compiler hangs in 2.6
 import sys
-if sys.version_info.major >= 2 and sys.version_info.minor > 6:
+if sys.version_info[0] * 10 + sys.version_info[1] > 26:
     import distutils.ccompiler
     distutils.ccompiler.CCompiler.compile = parallelCCompile
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=N
     cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
     # parallel code
 
-    N = min(N_cores, 4)  # number of parallel compilations
+    N = min(N_cores, len(objects) // 2)  # number of parallel compilations
+    print("Compiling", output_dir, "with", N, "threads.")
     import multiprocessing.pool
 
     def _single_compile(obj):

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,8 @@ def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=N
     cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
     # parallel code
 
-    N = min(N_cores, len(objects) // 2)  # number of parallel compilations
-    print("Compiling", output_dir, "with", N, "threads.")
+    N = min(N_cores, len(objects) // 2, 8)  # number of parallel compilations
+    print("Compiling with", N, "threads.")
     import multiprocessing.pool
 
     def _single_compile(obj):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,26 @@ import os
 import platform
 import distutils.sysconfig as sysconfig
 
+
+# monkey-patch for parallel compilation
+# from https://stackoverflow.com/questions/11013851/speeding-up-build-process-with-distutils
+def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=None, debug=0, extra_preargs=None, extra_postargs=None, depends=None):
+    # those lines are copied from distutils.ccompiler.CCompiler directly
+    macros, objects, extra_postargs, pp_opts, build = self._setup_compile(output_dir, macros, include_dirs, sources, depends, extra_postargs)
+    cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
+    # parallel code
+    N=2 # number of parallel compilations
+    import multiprocessing.pool
+    def _single_compile(obj):
+        try: src, ext = build[obj]
+        except KeyError: return
+        self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+    # convert to list, imap is evaluated on-demand
+    list(multiprocessing.pool.ThreadPool(N).imap(_single_compile,objects))
+    return objects
+import distutils.ccompiler
+distutils.ccompiler.CCompiler.compile=parallelCCompile
+
 # ----------------------------------------------------------------------------------------
 
 

--- a/src/db/db/dbHash.h
+++ b/src/db/db/dbHash.h
@@ -23,17 +23,21 @@
 
 #ifndef HDR_dbHash
 #define HDR_dbHash
-
-#if defined(__GNUC__)
-#   include <ext/hash_map>
-#   include <ext/hash_set>
-namespace std_ext = __gnu_cxx;
-#  define DB_HASH_NAMESPACE __gnu_cxx
-#else
-#   include <hash_map>
-#   include <hash_set>
+#if defined(__APPLE__) // clang compiler complains about deprecation warning on ext/hash_map and ext/hash_set
+#    include <unordered_map> 
+#    include <unordered_set>
+#    define DB_HASH_NAMESPACE std
 namespace std_ext = std;
-#  define DB_HASH_NAMESPACE std
+#elif defined(__GNUC__)
+#    include <ext/hash_map>
+#    include <ext/hash_set>
+namespace std_ext = __gnu_cxx;
+#    define DB_HASH_NAMESPACE __gnu_cxx
+#else
+#    include <hash_map>
+#    include <hash_set>
+namespace std_ext = std;
+#    define DB_HASH_NAMESPACE std
 #endif
 
 #include "dbPoint.h"
@@ -74,7 +78,7 @@ namespace DB_HASH_NAMESPACE
   };
 #endif
 
-#if defined(_WIN64) || defined(__APPLE__)
+#if defined(_WIN64)
   /**
    *  @brief Specialization missing for long long on WIN64
    */
@@ -98,6 +102,13 @@ namespace DB_HASH_NAMESPACE
       return size_t (__x ^ (__x >> 32));
     }
   };
+#endif
+
+#if defined(__APPLE__)
+  template<typename _Key, typename _Tp>
+  using hash_map = unordered_map<_Key, _Tp>;
+  template<typename _Value>
+  using hash_set = unordered_set<_Value>;
 #endif
 
   template <class T>

--- a/src/db/db/dbHash.h
+++ b/src/db/db/dbHash.h
@@ -23,7 +23,11 @@
 
 #ifndef HDR_dbHash
 #define HDR_dbHash
-#if defined(__APPLE__) // clang compiler complains about deprecation warning on ext/hash_map and ext/hash_set
+
+#if defined(__APPLE__)
+#define __EXT_HASH_DEPRECATED
+#endif
+#if defined(__EXT_HASH_DEPRECATED) // clang compiler complains about deprecation warning on ext/hash_map and ext/hash_set
 #    include <unordered_map> 
 #    include <unordered_set>
 #    define DB_HASH_NAMESPACE std
@@ -104,7 +108,7 @@ namespace DB_HASH_NAMESPACE
   };
 #endif
 
-#if defined(__APPLE__)
+#if defined(__EXT_HASH_DEPRECATED)
   template<typename _Key, typename _Tp>
   using hash_map = unordered_map<_Key, _Tp>;
   template<typename _Value>

--- a/src/db/db/dbPoint.h
+++ b/src/db/db/dbPoint.h
@@ -195,6 +195,20 @@ public:
   point<C> &operator*= (long s);
 
   /**
+   *  @brief Division by some divisor.
+   *
+   *  Scaline involves rounding which in our case is simply handled
+   *  with the coord_traits scheme.
+   */
+
+  point<C> &operator/= (double s);
+
+  /**
+   *  @brief Dividing self by some integer divisor
+   */
+  point<C> &operator/= (long s);
+
+  /**
    *  @brief The euclidian distance to another point
    *
    *  @param d The other to compute the distance to.
@@ -450,6 +464,32 @@ inline point<C>
 operator* (const db::point<C> &p, unsigned int s) 
 {
   return point<C> (p.x () * s, p.y () * s);
+}
+
+template <class C, typename Number>
+inline point<C>
+operator/ (const db::point<C> &p, Number s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  return point<C> (p.x () * mult, p.y () * mult);
+}
+
+template <class C>
+inline point<C> &
+point<C>::operator/= (double s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  *this *= mult;
+  return *this;
+}
+
+template <class C>
+inline point<C> &
+point<C>::operator/= (long s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  *this *= mult;
+  return *this;
 }
 
 template <class C>

--- a/src/db/db/dbVector.h
+++ b/src/db/db/dbVector.h
@@ -267,6 +267,20 @@ public:
   vector<C> operator*= (long s);
 
   /**
+   *  @brief Division by some divisor.
+   *
+   *  Scaline involves rounding which in our case is simply handled
+   *  with the coord_traits scheme.
+   */
+
+  vector<C> &operator/= (double s);
+
+  /**
+   *  @brief Dividing self by some integer divisor
+   */
+  vector<C> &operator/= (long s);
+
+  /**
    *  @brief The euclidian length 
    */
   distance_type length () const;
@@ -448,6 +462,32 @@ inline vector<C>
 vector<C>::operator* (long s) const
 {
   return vector<C> (m_x * s, m_y * s);
+}
+
+template <class C, typename Number>
+inline vector<C>
+operator/ (const db::vector<C> &p, Number s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  return vector<C> (p.x () * mult, p.y () * mult);
+}
+
+template <class C>
+inline vector<C> &
+vector<C>::operator/= (double s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  *this *= mult;
+  return *this;
+}
+
+template <class C>
+inline vector<C> &
+vector<C>::operator/= (long s)
+{
+  double mult = 1.0 / static_cast<double>(s);
+  *this *= mult;
+  return *this;
 }
 
 template <class C>

--- a/src/db/db/gsiDeclDbPoint.cc
+++ b/src/db/db/gsiDeclDbPoint.cc
@@ -70,6 +70,23 @@ struct point_defs
     return C (*p * s);
   }
 
+  static C divide (const C *p, double s)
+  {
+    return C (*p / s);
+  }
+
+  static C iscale (C *p, double s)
+  {
+    *p *= s;
+    return *p;
+  }
+
+  static C idiv (C *p, double s)
+  {
+    *p /= s;
+    return *p;
+  }
+
   static C negate (const C *p)
   {
     return -*p;
@@ -173,6 +190,30 @@ struct point_defs
       "@args f\n"
       "\n"
       "Returns the scaled object. All coordinates are multiplied with the given factor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("*=", &iscale,
+      "@brief Scaling by some factor\n"
+      "\n"
+      "@args f\n"
+      "\n"
+      "Scales object in place. All coordinates are multiplied with the given factor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("/", &divide,
+      "@brief Division by some divisor\n"
+      "\n"
+      "@args d\n"
+      "\n"
+      "Returns the scaled object. All coordinates are divided with the given divisor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("/=", &idiv,
+      "@brief Division by some divisor\n"
+      "\n"
+      "@args d\n"
+      "\n"
+      "Divides the object in place. All coordinates are divided with the given divisor and if "
       "necessary rounded."
     ) +
     method ("distance", (double (C::*) (const C &) const) &C::double_distance,

--- a/src/db/db/gsiDeclDbVector.cc
+++ b/src/db/db/gsiDeclDbVector.cc
@@ -70,6 +70,23 @@ struct vector_defs
     return C (*p * s);
   }
 
+  static C divide (const C *p, double s)
+  {
+    return C (*p / s);
+  }
+
+  static C iscale (C *p, double s)
+  {
+    *p *= s;
+    return *p;
+  }
+
+  static C idiv (C *p, double s)
+  {
+    *p /= s;
+    return *p;
+  }
+
   static C negate (const C *p)
   {
     return -*p;
@@ -200,6 +217,30 @@ struct vector_defs
       "@args f\n"
       "\n"
       "Returns the scaled object. All coordinates are multiplied with the given factor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("*=", &iscale,
+      "@brief Scaling by some factor\n"
+      "\n"
+      "@args f\n"
+      "\n"
+      "Scales object in place. All coordinates are multiplied with the given factor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("/", &divide,
+      "@brief Division by some divisor\n"
+      "\n"
+      "@args d\n"
+      "\n"
+      "Returns the scaled object. All coordinates are divided with the given divisor and if "
+      "necessary rounded."
+    ) +
+    method_ext ("/=", &idiv,
+      "@brief Division by some divisor\n"
+      "\n"
+      "@args d\n"
+      "\n"
+      "Divides the object in place. All coordinates are divided with the given divisor and if "
       "necessary rounded."
     ) +
     method_ext ("vprod", &vprod,

--- a/src/pya/pya/pyaModule.cc
+++ b/src/pya/pya/pyaModule.cc
@@ -493,7 +493,11 @@ static std::string extract_python_name (const std::string &name)
   } else if (name == "-@") {
     return "__neg__";
   } else if (name == "/") {
+    #if PY_MAJOR_VERSION < 3
     return "__div__";
+    #else
+    return "__truediv__";
+    #endif
   } else if (name == "*") {
     return "__mul__";
   } else if (name == "%") {
@@ -515,7 +519,11 @@ static std::string extract_python_name (const std::string &name)
   } else if (name == "-=") {
     return "__isub__";
   } else if (name == "/=") {
+    #if PY_MAJOR_VERSION < 3
     return "__idiv__";
+    #else
+    return "__itruediv__";
+    #endif
   } else if (name == "*=") {
     return "__imul__";
   } else if (name == "%=") {

--- a/src/pya/pya/pyaModule.cc
+++ b/src/pya/pya/pyaModule.cc
@@ -2698,6 +2698,11 @@ PythonModule::make_classes (const char *mod_name)
               add_python_doc (*c, mt, mid, tl::to_string (tr ("This method enables iteration of the object")));
               alt_names.push_back ("__iter__");
 
+            } else if (name == "__mul__") {
+              // Adding right multiplication
+              // Rationale: if pyaObj * x works, so should x * pyaObj
+              add_python_doc (*c, mt, mid, tl::to_string (tr ("This method is also available as '__mul__'")));
+              alt_names.push_back ("__rmul__");
             }
 
             for (std::vector <std::string>::const_iterator an = alt_names.begin (); an != alt_names.end (); ++an) {

--- a/src/tl/tl/tlThreads.cc
+++ b/src/tl/tl/tlThreads.cc
@@ -24,6 +24,7 @@
 
 #include "tlThreads.h"
 #include "tlUtils.h"
+#include "tlTimer.h"
 #include "tlLog.h"
 #include "tlInternational.h"
 

--- a/src/tl/tl/tlTimer.cc
+++ b/src/tl/tl/tlTimer.cc
@@ -22,7 +22,6 @@
 
 
 #include "tlTimer.h"
-#include "tlUtils.h"
 #include "tlLog.h"
 #include "tlString.h"
 


### PR DESCRIPTION
I've made a few improvements to pymod:

- `setup.py` now builds with multithread, like a make -j 4. not tested in windows.
- upgraded deprecated ext/hash_(map|set) to unordered_(map|set) (mac only right now, but feel free to extend to linux)
- bugfix: forgot to include `tlTimer.h` in `src/tl/tl/tlThreads.cc`
- pyaModule improvement: added `__rmul__` as alias to `__mul__` (3 * point works!)
- db.(point|vector) improvement: included division to float or integer (point / 3.0). 
- Also implemented in-place operations `*=` and `/=`. (but somehow python interaface objects still mutate. was trying to avoid that.)
- travis ci builds wheels for the following (deploys to [dropbox](https://www.dropbox.com/sh/xekinbrjagwtyps/AACd9iRy1Mxc1AhZrLtJfU0Da?dl=0)): 
    + ubuntu 14 - py 2.6
    + ubuntu 14 - py 2.7
    + ubuntu 14 - py 3.3
    + ubuntu 14 - py 3.4
    + ubuntu 14 - py 3.5
    + ubuntu 14 - py 3.6
    + macOS 10.11 - py 2.7 (native)
    + macOS 10.12 - py 2.7 (brew)
    + macOS 10.13 - py 2.7 (native)
    + macOS 10.11 - py 3.7 (brew)
    + macOS 10.12 - py 3.7 (brew)
    + macOS 10.13 - py 3.7 (brew)