### PR TITLE
more hiDPI improvements

### DIFF
--- a/src/laybasic/laybasic/layDitherPattern.cc
+++ b/src/laybasic/laybasic/layDitherPattern.cc
@@ -555,6 +555,7 @@ DitherPatternInfo::operator< (const DitherPatternInfo &d) const
   return m_order_index < d.m_order_index;
 }
 
+// TODO including a scaling algorithm in this formula, or give more resolution to the dither
 QBitmap
 DitherPatternInfo::get_bitmap (int width, int height) const
 {

--- a/src/laybasic/laybasic/layLayerToolbox.cc
+++ b/src/laybasic/laybasic/layLayerToolbox.cc
@@ -200,16 +200,25 @@ LCPDitherPalette::create_pixmap_for (LCPActiveLabel *b, int n)
   const unsigned int h = 24;
   const unsigned int w = 24;
 
-  QImage image (w, h, QImage::Format_RGB32);
-  image.fill (color0.rgb ());
+#if QT_VERSION > 0x050000
+  unsigned int dpr = devicePixelRatio ();
+#else
+  unsigned int dpr = 1;
+#endif
 
-  QBitmap bitmap = pattern.pattern (n).get_bitmap (w, h);
+  QImage image (w * dpr, h * dpr, QImage::Format_RGB32);
+  image.fill (color0.rgb ());
+  image.setDevicePixelRatio(dpr);
+
+  // TODO include a scaling algorithm in get_bitmap, because it looks small in highDPI screens
+  QBitmap bitmap = pattern.pattern (n).get_bitmap (w * dpr, h * dpr);
   QPainter painter (&image);
   painter.setPen (QPen (color1));
   painter.setBackgroundMode (Qt::TransparentMode);
-  painter.drawPixmap (0, 0, bitmap);
+  painter.drawPixmap (0, 0, w, h, bitmap);
 
   QPixmap pixmap = QPixmap::fromImage (image); // Qt 4.6.0 workaround
+  pixmap.setDevicePixelRatio(dpr);
   b->setPixmap (pixmap);
 }
 
@@ -629,16 +638,24 @@ LCPStylePalette::create_pixmap_for_line_style (LCPActiveLabel *b, int n)
   const unsigned int h = 14;
   const unsigned int w = 24;
 
-  QImage image (w, h, QImage::Format_RGB32);
-  image.fill (color0.rgb ());
+#if QT_VERSION > 0x050000
+  unsigned int dpr = devicePixelRatio ();
+#else
+  unsigned int dpr = 1;
+#endif
 
-  QBitmap bitmap = styles.style (n).get_bitmap (w, h);
+  QImage image (dpr * w, dpr * h, QImage::Format_RGB32);
+  image.fill (color0.rgb ());
+  image.setDevicePixelRatio(dpr);
+
+  QBitmap bitmap = styles.style (n).get_bitmap (dpr * w, dpr * h);
   QPainter painter (&image);
   painter.setPen (QPen (color1));
   painter.setBackgroundMode (Qt::TransparentMode);
-  painter.drawPixmap (0, 0, bitmap);
+  painter.drawPixmap (0, 0, w, h, bitmap);
 
   QPixmap pixmap = QPixmap::fromImage (image); // Qt 4.6.0 workaround
+  pixmap.setDevicePixelRatio(dpr);
   b->setPixmap (pixmap);
 }
 

--- a/src/laybasic/laybasic/layLayoutCanvas.cc
+++ b/src/laybasic/laybasic/layLayoutCanvas.cc
@@ -291,8 +291,6 @@ LayoutCanvas::LayoutCanvas (QWidget *parent, lay::LayoutView *view, const char *
 {
 #if QT_VERSION > 0x050000
   m_dpr = devicePixelRatio ();
-#else
-  m_dpr = 1;
 #endif
 
   //  The gamma value used for subsampling: something between 1.8 and 2.2.

--- a/src/laybasic/laybasic/layLayoutViewConfigPages.cc
+++ b/src/laybasic/laybasic/layLayoutViewConfigPages.cc
@@ -1366,16 +1366,24 @@ LayoutViewConfigPage6a::update ()
     const unsigned int h = 26;
     const unsigned int w = 26;
 
-    QImage image (w, h, QImage::Format_RGB32);
-    image.fill (color0.rgb ());
+#if QT_VERSION > 0x050000
+    unsigned int dpr = devicePixelRatio ();
+#else
+    unsigned int dpr = 1;
+#endif
 
-    QBitmap bitmap = m_style.style (s).get_bitmap (w, h);
+    QImage image (w * dpr, h * dpr, QImage::Format_RGB32);
+    image.fill (color0.rgb ());
+    image.setDevicePixelRatio(dpr);
+
+    QBitmap bitmap = m_style.style (s).get_bitmap (w * dpr, h * dpr);
     QPainter painter (&image);
     painter.setPen (QPen (color1));
     painter.setBackgroundMode (Qt::TransparentMode);
-    painter.drawPixmap (0, 0, bitmap);
+    painter.drawPixmap (0, 0, w, h, bitmap);
 
     QPixmap pixmap = QPixmap::fromImage (image); // Qt 4.6.0 workaround
+    pixmap.setDevicePixelRatio(dpr);
     b->setIconSize (pixmap.size ());
     b->setIcon (QIcon (pixmap));
 

--- a/src/laybasic/laybasic/layLayoutViewConfigPages.cc
+++ b/src/laybasic/laybasic/layLayoutViewConfigPages.cc
@@ -819,9 +819,20 @@ LayoutViewConfigPage4::update ()
       }
     }
 
+#if QT_VERSION > 0x050000
+    unsigned int dpr = 1; //devicePixelRatio ();
+#else
+    unsigned int dpr = 1;
+#endif
+
     QFontMetrics fm (font (), this);
     QRect rt (fm.boundingRect (QString::fromUtf8 ("AA")));
-    QPixmap pxmp (rt.width () + 10, rt.height () + 10);
+
+    const unsigned int h = rt.height () + 10;
+    const unsigned int w = rt.weight () + 10;
+
+    QPixmap pxmp (w * dpr, h * dpr);
+    pxmp.setDevicePixelRatio(dpr);
 
     QPainter pxpainter (&pxmp);
     pxpainter.setPen (QPen (palette ().color (QPalette::Active, QPalette::Text)));
@@ -1159,35 +1170,51 @@ LayoutViewConfigPage6::update ()
     const unsigned int h = rt.height () + 10;
     const unsigned int w = rt.width () + 10;
 
-    unsigned int color0 = palette ().color (QPalette::Active, QPalette::Button).rgb();
-    unsigned int color1 = palette ().color (QPalette::Active, QPalette::Dark).rgb();
+    QColor color0 = palette ().color (QPalette::Active, QPalette::Button);
+    QColor color1 = palette ().color (QPalette::Active, QPalette::Dark);
 
-    QImage image (w, h, QImage::Format_RGB32);
-    if (s >= 0) {
-      const uint32_t * const *dp = m_pattern.pattern ((unsigned int) s).pattern ();
-      for (unsigned int l = 0; l < h; ++l, ++dp) {
-        uint32_t m = **dp;
-        if (l == 0 || l == h - 1) { 
-          m |= ((1 << w) - 1);
-        } else {
-          m |= ((1 << (w - 1)) | 1);
-        }
-        color_t *pt = (color_t *) image.scanLine (h - 1 - l);
-        for (unsigned int b = 0; b < w; ++b) {
-          *pt++ = (m & 1) ? color1 : color0;
-          m >>= 1;
-        }
-      }
-    }
+#if QT_VERSION > 0x050000
+    unsigned int dpr = 1; //devicePixelRatio ();
+#else
+    unsigned int dpr = 1;
+#endif
+
+    QImage image (w * dpr, h * dpr, QImage::Format_RGB32);
+    image.setDevicePixelRatio(dpr);
+    image.fill (color0.rgb ());
+    // if (s >= 0) {
+    //   const uint32_t * const *dp = m_pattern.pattern ((unsigned int) s).pattern ();
+    //   for (unsigned int l = 0; l < h; ++l, ++dp) {
+    //     uint32_t m = **dp;
+    //     if (l == 0 || l == h - 1) { 
+    //       m |= ((1 << w) - 1);
+    //     } else {
+    //       m |= ((1 << (w - 1)) | 1);
+    //     }
+    //     color_t *pt = (color_t *) image.scanLine (h - 1 - l);
+    //     for (unsigned int b = 0; b < w; ++b) {
+    //       *pt++ = (m & 1) ? color1 : color0;
+    //       m >>= 1;
+    //     }
+    //   }
+    // }
+
+    // copying code from layLayerToolbox.cc
+    QBitmap bitmap = m_pattern.pattern ((unsigned int) s).get_bitmap (w * dpr, h * dpr);
+    QPainter painter (&image);
+    painter.setPen (QPen (color1));
+    painter.setBackgroundMode (Qt::TransparentMode);
+    painter.drawPixmap (0, 0, w, h, bitmap);
 
     QPixmap pxmp = QPixmap::fromImage (image); // Qt 4.6.0 workaround
-
     QPainter pxpainter (&pxmp);
     pxpainter.setPen (QPen (palette ().color (QPalette::Active, QPalette::Text)));
     QRect r (0, 0, pxmp.width () - 1, pxmp.height () - 1);
     pxpainter.drawRect (r);
     pxpainter.setFont (font ());
     pxpainter.drawText (r, Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine, text);
+
+    pxmp.setDevicePixelRatio(dpr);
 
     (mp_ui->*(cfg6_buttons [i]))->setIconSize (pxmp.size ());
     (mp_ui->*(cfg6_buttons [i]))->setIcon (QIcon (pxmp));
@@ -1367,7 +1394,7 @@ LayoutViewConfigPage6a::update ()
     const unsigned int w = 26;
 
 #if QT_VERSION > 0x050000
-    unsigned int dpr = devicePixelRatio ();
+    unsigned int dpr = 1; //devicePixelRatio ();
 #else
     unsigned int dpr = 1;
 #endif


### PR DESCRIPTION
Attempt to fully address #94 

- Layout Toolbox now shows hiDPI stipple patterns and line style buttons.
- I placed placeholder code for upgrading the buttons in the Config page to hiDPI, but unfortunately `QIcon (pixmap)` is not painted by the widget in hiDPI (couldn't figure out why -- very annoying).

@klayoutmatthias if we can figure out an easy way to not use QIcon, that would be ideal.

TODO:
- change the stipple pattern definition to not be dependent on 8-bit char, so that we can use a higher def version (e.g. 16-bit) of each stipple (the current ones look very dense in hiDPI). OR write a fancy algorithm to automatically convert and smooth the patterns. (I would vote for the hard-code though).