### PR TITLE
fixing test test_42 in qtbinding.py and adding note to qtbinding.rb

### DIFF
--- a/testdata/python/qtbinding.py
+++ b/testdata/python/qtbinding.py
@@ -471,9 +471,11 @@ class QtBindingTest(unittest.TestCase):
 
     pya.QApplication.processEvents()
 
-    s1 = "QKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)" 
-    s2 = "QKeyEvent: KeyPress (6)\nQKeyEvent: KeyPress (6)\nQKeyEvent: KeyPress (6)" 
-    self.assertEqual("\n".join(ef.log()) == s1 or "\n".join(ef.log()) == s2, True)
+    s1 = "QKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)"
+    s2 = "QKeyEvent: KeyPress (6)\nQKeyEvent: KeyPress (6)\nQKeyEvent: KeyPress (6)"
+    s3 = "QKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)"
+    self.assertIn("\n".join(ef.log()), (s1, s2, s3))
+
     ef = None
 
     self.assertEqual(widget.text, "ABCpO")

--- a/testdata/ruby/qtbinding.rb
+++ b/testdata/ruby/qtbinding.rb
@@ -534,7 +534,10 @@ class QtBinding_TestClass < TestBase
 
     GC.start
 
-    assert_equal(ef.log.select { |s| s !~ /RBA::QKeyEvent: ShortcutOverride/ }.join("\n"), "RBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent: KeyPress (6)") 
+    assert_equal(ef.log.select { |s| s !~ /RBA::QKeyEvent: ShortcutOverride/ }.join("\n"), "RBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent: KeyPress (6)")
+
+    # TODO: on macOS 10.13, ef.log yields "RBA::QKeyEvent_Native: ShortcutOverride (51)\nRBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent_Native: ShortcutOverride (51)\nRBA::QKeyEvent: KeyPress (6)\nRBA::QKeyEvent_Native: ShortcutOverride (51)\nRBA::QKeyEvent: KeyPress (6)", causing this test to fail.
+
     ef = nil
     ef = EventFilter::new
     GC.start


### PR DESCRIPTION
Instead of returning 
`"QKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)"`
 my computer returns:
`QKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)\nQKeyEvent_Native: ShortcutOverride (51)\nQKeyEvent: KeyPress (6)`

Note the difference between QKeyEvent and QKeyEvent_Native. I judged this wasn't a big issue, so I've added the test case.

Sorry, don't know ruby, so I couldn't quickly fix qtbinding.rb.