### PR TITLE
Pymod travis optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ matrix:
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
         - CC=clang
+        - CXX=clang++
 
     - name: "klayout python3.6 package"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,19 @@ matrix:
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
     
+    - name: "klayout python3.7 package"
+      os: linux
+      dist: trusty # Ubuntu 14.04
+      sudo: false
+      language: python
+      python: '3.7-dev'
+      env:
+        - MATRIX_EVAL=""
+        - PIP_UPDATE="1"
+        - PYTHON_BUILD=true
+        - BREW_BUNDLE=false
+        - CC=clang
+
     - name: "klayout python3.6 package"
       os: linux
       dist: trusty # Ubuntu 14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,8 @@ matrix:
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
     
     - name: "klayout python2.7 package"
       os: linux
@@ -111,6 +113,8 @@ matrix:
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
     
     - name: "klayout python2.6 package"
       os: linux
@@ -123,6 +127,8 @@ matrix:
         - PIP_UPDATE="0"  # setuptools installed from last pip has syntax error on py 2.6
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
     
     - name: "klayout python3.3 package"
       os: linux
@@ -135,6 +141,8 @@ matrix:
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
     
     - name: "klayout python3.4 package"
       os: linux
@@ -147,6 +155,8 @@ matrix:
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
     
     - name: "klayout python3.5 package"
       os: linux
@@ -159,6 +169,8 @@ matrix:
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true
         - BREW_BUNDLE=false
+        - CC=clang
+        - CXX=clang++
 
     # KLayout builds for mac
     # Python 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,31 @@ matrix:
         - PYTHON_BUILD=true
         - BREW_BUNDLE=true
 
-    - name: "klayout python3.6.5_1 osx10.13"
+    - name: "klayout python3.6.6 osx10.13"
       os: osx
       osx_image: xcode9.4  # macOS 10.13
       env:
-        - MATRIX_EVAL="brew update; brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb; brew switch python 3.6.5_1; shopt -s expand_aliases; alias python='python3'; alias pip='pip3';"
+        - MATRIX_EVAL="brew update; brew install sashkab/python/python36; brew link --force --overwrite python36; shopt -s expand_aliases; alias python='/usr/local/opt/python36/bin/python3.6'; alias pip='/usr/local/opt/python36/bin/pip3.6';"
+        - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
+        - PYTHON_BUILD=true
+        - BREW_BUNDLE=false
+
+    - name: "klayout python3.5.6 osx10.13"
+      os: osx
+      osx_image: xcode9.4  # macOS 10.13
+      env:
+        - MATRIX_EVAL="brew update; brew install sashkab/python/python35; brew link --force --overwrite python35; shopt -s expand_aliases; alias python='/usr/local/opt/python35/bin/python3.5'; alias pip='/usr/local/opt/python35/bin/pip3.5';"
+        - ARCHFLAGS="-std=c++11"
+        - PIP_UPDATE="1"
+        - PYTHON_BUILD=true
+        - BREW_BUNDLE=false
+
+    - name: "klayout python3.4.9 osx10.13"
+      os: osx
+      osx_image: xcode9.4  # macOS 10.13
+      env:
+        - MATRIX_EVAL="brew update; brew install sashkab/python/python34; brew link --force --overwrite python34; shopt -s expand_aliases; alias python='/usr/local/opt/python34/bin/python3.4'; alias pip='/usr/local/opt/python34/bin/pip3.4';"
         - ARCHFLAGS="-std=c++11"
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -257,7 +257,6 @@ matrix:
 
 before_install:
   - env
-  - rvm install ruby --latest
   - gem install dropbox-deployment
   - eval "${MATRIX_EVAL}"
   - if [ "$BREW_BUNDLE" = true ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       os: osx
       osx_image: xcode8  # macOS 10.11
       env:
-        - MATRIX_EVAL="brew update; brew config; brew upgrade python;"
+        - MATRIX_EVAL="brew update; brew config; brew upgrade python; brew postinstall python; ls -l /usr/local/opt/python/libexec/bin/; shopt -s expand_aliases; alias python='/usr/local/opt/python/libexec/bin/python'; alias pip='/usr/local/opt/python/libexec/bin/pip';"
         - ARCHFLAGS="-std=c++11"
         - PIP_UPDATE="1"
         - PYTHON_BUILD=true

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ class Config(object):
             return []
         else:
             return ["-Wno-strict-aliasing",  # Avoids many "type-punned pointer" warnings
-                    "-std=c++0x",  # because we use unordered_map/unordered_set
+                    "-std=c++11",  # because we use unordered_map/unordered_set
                     ]
 
     def link_args(self, mod):


### PR DESCRIPTION
- Fixed bug that prevented wheel building of py3 in macOS10.11
- Added wheel building of python 3.6, 3.5 and 3.4 in macOS10.13
- Changed linux compilers to clang (brought down from 80Mb to 50Mb)
- Added linux build with py3.7
- Changed linux build flag from `-std=c++0x` to `-std=c++11`

Tests are passing.
I am considering moving to Microsoft Azure. Since last month, they now offer opensource builds with unlimited time for Mac, Linux and Windows!