### PR TITLE
First solution provided for ticket #191

### DIFF
--- a/src/lay/lay/layApplication.h
+++ b/src/lay/lay/layApplication.h
@@ -62,6 +62,7 @@ namespace lay
 {
 
 class MainWindow;
+class PluginRootToMainWindow;
 class PluginRoot;
 class ProgressReporter;
 class ProgressBar;
@@ -475,6 +476,7 @@ protected:
 
 private:
   MainWindow *mp_mw;
+  PluginRootToMainWindow *mp_plugin_root;
   gtf::Recorder *mp_recorder;
   std::auto_ptr<tl::DeferredMethodScheduler> mp_dm_scheduler;
 };

--- a/src/lay/lay/layMacroController.cc
+++ b/src/lay/lay/layMacroController.cc
@@ -162,11 +162,10 @@ MacroController::finish ()
 void
 MacroController::initialized (lay::PluginRoot *root)
 {
-  mp_mw = dynamic_cast <lay::MainWindow *> (root);
-  if (mp_mw) {
-    mp_macro_editor = new lay::MacroEditorDialog (mp_mw, &lym::MacroCollection::root ());
-    mp_macro_editor->setModal (false);
-  }
+  mp_mw = lay::MainWindow::instance ();
+
+  mp_macro_editor = new lay::MacroEditorDialog (root, &lym::MacroCollection::root ());
+  mp_macro_editor->setModal (false);
 
   if (! m_file_watcher) {
     m_file_watcher = new tl::FileSystemWatcher (this);

--- a/src/lay/lay/layMacroEditorDialog.cc
+++ b/src/lay/lay/layMacroEditorDialog.cc
@@ -227,10 +227,10 @@ public:
 
 static lay::MacroEditorDialog *s_macro_editor_instance = 0;
 
-MacroEditorDialog::MacroEditorDialog (lay::MainWindow *mw, lym::MacroCollection *root)
+MacroEditorDialog::MacroEditorDialog (lay::PluginRoot *pr, lym::MacroCollection *root)
   : QDialog (0 /*show as individual top widget*/, Qt::Window),
-    lay::Plugin (mw, true),
-    mp_plugin_root (mw),
+    lay::Plugin (pr, true),
+    mp_plugin_root (pr),
     mp_root (root),
     m_first_show (true), m_in_processing (false), m_debugging_on (true),
     mp_run_macro (0),

--- a/src/lay/lay/layMacroEditorDialog.h
+++ b/src/lay/lay/layMacroEditorDialog.h
@@ -98,7 +98,7 @@ public:
   /**
    *  @brief Constructor
    */
-  MacroEditorDialog (lay::MainWindow *parent, lym::MacroCollection *root);
+  MacroEditorDialog (lay::PluginRoot *pr, lym::MacroCollection *root);
 
   /**
    *  @brief Destructor

--- a/src/lay/lay/layMainWindow.cc
+++ b/src/lay/lay/layMainWindow.cc
@@ -468,7 +468,7 @@ MainWindow::MainWindow (QApplication *app, const char *name)
   }
   mw_instance = this;
 
-  mp_setup_form = new SettingsForm (0, this, "setup_form"),
+  mp_setup_form = new SettingsForm (0, lay::PluginRoot::instance (), "setup_form"),
 
   db::LibraryManager::instance ().changed_event.add (this, &MainWindow::libraries_changed);
 
@@ -1077,13 +1077,13 @@ void
 MainWindow::dock_widget_visibility_changed (bool /*visible*/)
 {
   if (sender () == mp_lp_dock_widget) {
-    config_set (cfg_show_layer_panel, tl::to_string (!mp_lp_dock_widget->isHidden ()));
+    lay::PluginRoot::instance ()->config_set (cfg_show_layer_panel, tl::to_string (!mp_lp_dock_widget->isHidden ()));
   } else if (sender () == mp_hp_dock_widget) {
-    config_set (cfg_show_hierarchy_panel, tl::to_string (!mp_hp_dock_widget->isHidden ()));
+    lay::PluginRoot::instance ()->config_set (cfg_show_hierarchy_panel, tl::to_string (!mp_hp_dock_widget->isHidden ()));
   } else if (sender () == mp_navigator_dock_widget) {
-    config_set (cfg_show_navigator, tl::to_string (!mp_navigator_dock_widget->isHidden ()));
+    lay::PluginRoot::instance ()->config_set (cfg_show_navigator, tl::to_string (!mp_navigator_dock_widget->isHidden ()));
   } else if (sender () == mp_layer_toolbox_dock_widget) {
-    config_set (cfg_show_layer_toolbox, tl::to_string (!mp_layer_toolbox_dock_widget->isHidden ()));
+    lay::PluginRoot::instance ()->config_set (cfg_show_layer_toolbox, tl::to_string (!mp_layer_toolbox_dock_widget->isHidden ()));
   }
 }
 
@@ -1259,7 +1259,7 @@ MainWindow::about_to_exec ()
   bool f;
 
   f = false;
-  config_get (cfg_full_hier_new_cell, f);
+  lay::PluginRoot::instance ()->config_get (cfg_full_hier_new_cell, f);
   if (!f) {
     TipDialog td (this,
                   tl::to_string (QObject::tr ("<html><body>"
@@ -1278,7 +1278,7 @@ MainWindow::about_to_exec ()
     lay::TipDialog::button_type button = lay::TipDialog::null_button;
     if (td.exec_dialog (button)) {
       if (button == lay::TipDialog::yes_button) {
-        config_set (cfg_full_hier_new_cell, true);
+        lay::PluginRoot::instance ()->config_set (cfg_full_hier_new_cell, true);
       }
       //  Don't bother the user with more dialogs.
       return;
@@ -1297,7 +1297,7 @@ MainWindow::about_to_exec ()
   }
 
   f = false;
-  config_get (cfg_no_stipple, f);
+  lay::PluginRoot::instance ()->config_get (cfg_no_stipple, f);
   if (f) {
     TipDialog td (this,
                   tl::to_string (QObject::tr ("Layers are shown without fill because fill has been intentionally turned off. This can be confusing since selecting a stipple does not have an effect in this case.\n\nTo turn this feature off, uncheck \"Show Layers Without Fill\" in the \"View\" menu.")),
@@ -1309,7 +1309,7 @@ MainWindow::about_to_exec ()
   }
 
   f = false;
-  config_get (cfg_markers_visible, f);
+  lay::PluginRoot::instance ()->config_get (cfg_markers_visible, f);
   if (! f) {
     TipDialog td (this,
                   tl::to_string (QObject::tr ("Markers are not visible because they have been turned off.\nYou may not see markers when using the marker browser feature.\n\nTo turn markers on, check \"Show Markers\" in the \"View\" menu.")),
@@ -1321,7 +1321,7 @@ MainWindow::about_to_exec ()
   }
 
   f = false;
-  config_get (cfg_hide_empty_layers, f);
+  lay::PluginRoot::instance ()->config_get (cfg_hide_empty_layers, f);
   if (f) {
     TipDialog td (this,
                   tl::to_string (QObject::tr ("The \"Hide Empty Layers\" feature is enabled. This can be confusing, in particular in edit mode, because layers are not shown although they are actually present.\n\nTo disable this feature, uncheck \"Hide Empty Layers\" in the layer panel's context menu.")),
@@ -1813,10 +1813,10 @@ MainWindow::libraries_changed ()
 void
 MainWindow::read_dock_widget_state ()
 {
-  config_set (cfg_show_layer_panel, tl::to_string (!mp_lp_dock_widget->isHidden ()));
-  config_set (cfg_show_hierarchy_panel, tl::to_string (!mp_hp_dock_widget->isHidden ()));
-  config_set (cfg_show_navigator, tl::to_string (!mp_navigator_dock_widget->isHidden ()));
-  config_set (cfg_show_layer_toolbox, tl::to_string (!mp_layer_toolbox_dock_widget->isHidden ()));
+  lay::PluginRoot::instance ()->config_set (cfg_show_layer_panel, tl::to_string (!mp_lp_dock_widget->isHidden ()));
+  lay::PluginRoot::instance ()->config_set (cfg_show_hierarchy_panel, tl::to_string (!mp_hp_dock_widget->isHidden ()));
+  lay::PluginRoot::instance ()->config_set (cfg_show_navigator, tl::to_string (!mp_navigator_dock_widget->isHidden ()));
+  lay::PluginRoot::instance ()->config_set (cfg_show_layer_toolbox, tl::to_string (!mp_layer_toolbox_dock_widget->isHidden ()));
 }
 
 void
@@ -1929,7 +1929,7 @@ MainWindow::can_close ()
 
   for (tl::Registrar<lay::PluginDeclaration>::iterator cls = tl::Registrar<lay::PluginDeclaration>::begin (); cls != tl::Registrar<lay::PluginDeclaration>::end (); ++cls) {
     lay::PluginDeclaration *pd = const_cast<lay::PluginDeclaration *> (&*cls);
-    if (! pd->can_exit (this)) {
+    if (! pd->can_exit (lay::PluginRoot::instance ())) {
       return false;
     }
   }
@@ -1974,8 +1974,8 @@ MainWindow::save_state_to_config ()
 {
   //  save the dock widget state with all views closed (that state can be
   //  used for staring klayout without any layout)
-  config_set (cfg_window_geometry, (const char *) saveGeometry ().toBase64 ().data ());
-  config_set (cfg_window_state, (const char *) saveState ().toBase64 ().data ());
+  lay::PluginRoot::instance ()->config_set (cfg_window_geometry, (const char *) saveGeometry ().toBase64 ().data ());
+  lay::PluginRoot::instance ()->config_set (cfg_window_state, (const char *) saveState ().toBase64 ().data ());
 }
 
 void
@@ -3400,13 +3400,13 @@ MainWindow::cm_pull_in ()
 void
 MainWindow::cm_reader_options ()
 {
-  mp_layout_load_options->edit_global_options (this, lay::Technologies::instance ());
+  mp_layout_load_options->edit_global_options (lay::PluginRoot::instance (), lay::Technologies::instance ());
 }
 
 void
 MainWindow::cm_writer_options ()
 {
-  mp_layout_save_options->edit_global_options (this, lay::Technologies::instance ());
+  mp_layout_save_options->edit_global_options (lay::PluginRoot::instance (), lay::Technologies::instance ());
 }
 
 void
@@ -3675,7 +3675,7 @@ MainWindow::clone_current_view ()
   }
 
   //  create a new view
-  view = new lay::LayoutView (current_view (), &m_manager, lay::ApplicationBase::instance ()->is_editable (), this, mp_view_stack);
+  view = new lay::LayoutView (current_view (), &m_manager, lay::ApplicationBase::instance ()->is_editable (), lay::PluginRoot::instance (), mp_view_stack);
   connect (view, SIGNAL (title_changed ()), this, SLOT (view_title_changed ()));
   connect (view, SIGNAL (dirty_changed ()), this, SLOT (view_title_changed ()));
   connect (view, SIGNAL (edits_enabled_changed ()), this, SLOT (edits_enabled_changed ()));
@@ -4111,7 +4111,7 @@ MainWindow::add_mru (const std::string &fn_rel, const std::string &tech)
     }
   }
 
-  config_set (cfg_mru, config_str);
+  lay::PluginRoot::instance ()->config_set (cfg_mru, config_str);
 }
 
 void
@@ -4164,7 +4164,7 @@ MainWindow::open_recent ()
     return;
   }
 
-  if (mp_layout_load_options->show_always () && !mp_layout_load_options->edit_global_options (this, lay::Technologies::instance ())) {
+  if (mp_layout_load_options->show_always () && !mp_layout_load_options->edit_global_options (lay::PluginRoot::instance (), lay::Technologies::instance ())) {
     return;
   }
 
@@ -4213,7 +4213,7 @@ MainWindow::open (int mode)
     return;
   }
 
-  if (mp_layout_load_options->show_always () && !mp_layout_load_options->edit_global_options (this, lay::Technologies::instance ())) {
+  if (mp_layout_load_options->show_always () && !mp_layout_load_options->edit_global_options (lay::PluginRoot::instance (), lay::Technologies::instance ())) {
     return;
   }
 
@@ -4284,7 +4284,7 @@ int
 MainWindow::do_create_view ()
 {
   //  create a new view
-  lay::LayoutView *view = new lay::LayoutView (&m_manager, lay::ApplicationBase::instance ()->is_editable (), this, mp_view_stack);
+  lay::LayoutView *view = new lay::LayoutView (&m_manager, lay::ApplicationBase::instance ()->is_editable (), lay::PluginRoot::instance (), mp_view_stack);
 
   connect (view, SIGNAL (title_changed ()), this, SLOT (view_title_changed ()));
   connect (view, SIGNAL (dirty_changed ()), this, SLOT (view_title_changed ()));
@@ -4305,7 +4305,7 @@ MainWindow::do_create_view ()
   view->set_synchronous (synchronous ());
 
   int tl = 0;
-  config_get (cfg_initial_hier_depth, tl);
+  lay::PluginRoot::instance ()->config_get (cfg_initial_hier_depth, tl);
   view->set_hier_levels (std::make_pair (0, tl));
 
   //  select the current mode and select the enabled editables
@@ -4364,7 +4364,7 @@ MainWindow::create_or_load_layout (const std::string *filename, const db::LoadLa
     if (mode == 0) {
       //  reset the hierarchy depth in the "replace" case
       int tl = 0;
-      config_get (cfg_initial_hier_depth, tl);
+      lay::PluginRoot::instance ()->config_get (cfg_initial_hier_depth, tl);
       vw->set_hier_levels (std::make_pair (0, tl));
       vw->clear_states ();
       vw->store_state ();
@@ -4564,7 +4564,7 @@ MainWindow::get_hier_levels () const
     return current_view ()->get_hier_levels ();
   } else {
     int tl = 0;
-    config_get (cfg_initial_hier_depth, tl);
+    lay::PluginRoot::instance ()->config_get (cfg_initial_hier_depth, tl);
     return std::make_pair (0, tl);
   }
 }
@@ -4861,8 +4861,8 @@ MainWindow::show_assistant_topic (const std::string &s, bool modal)
 void
 MainWindow::cm_show_all_tips ()
 {
-  config_set (cfg_tip_window_hidden, "");
-  config_finalize ();
+  lay::PluginRoot::instance ()->config_set (cfg_tip_window_hidden, "");
+  lay::PluginRoot::instance ()->config_end ();
 }
 
 void
@@ -4894,7 +4894,7 @@ MainWindow::action_for_slot (const char *slot)
 lay::Action *
 MainWindow::create_config_action (const std::string &title, const std::string &cname, const std::string &cvalue)
 {
-  lay::ConfigureAction *ca = new lay::ConfigureAction(this, title, cname, cvalue);
+  lay::ConfigureAction *ca = new lay::ConfigureAction(lay::PluginRoot::instance (), title, cname, cvalue);
   m_ca_collection.push_back (ca);
   return ca;
 }
@@ -4902,7 +4902,7 @@ MainWindow::create_config_action (const std::string &title, const std::string &c
 lay::Action *
 MainWindow::create_config_action (const std::string &cname, const std::string &cvalue)
 {
-  lay::ConfigureAction *ca = new lay::ConfigureAction(this, std::string (), cname, cvalue);
+  lay::ConfigureAction *ca = new lay::ConfigureAction(lay::PluginRoot::instance (), std::string (), cname, cvalue);
   m_ca_collection.push_back (ca);
   return ca;
 }
@@ -5600,11 +5600,8 @@ MainWindow::plugin_registered (lay::PluginDeclaration *cls)
 
   //  recreate all plugins
   for (std::vector <lay::LayoutView *>::iterator vp = mp_views.begin (); vp != mp_views.end (); ++vp) {
-    (*vp)->create_plugins (this);
+    (*vp)->create_plugins (lay::PluginRoot::instance ());
   }
-
-  //  re-establish the configuration
-  config_setup ();
 }
 
 void
@@ -5614,11 +5611,79 @@ MainWindow::plugin_removed (lay::PluginDeclaration *cls)
 
   //  recreate all plugins except the one that got removed
   for (std::vector <lay::LayoutView *>::iterator vp = mp_views.begin (); vp != mp_views.end (); ++vp) {
-    (*vp)->create_plugins (this, cls);
+    (*vp)->create_plugins (lay::PluginRoot::instance (), cls);
+  }
+}
+
+// ------------------------------------------------------------
+//  Implementation of the PluginRootToMainWindow bride
+
+PluginRootToMainWindow::PluginRootToMainWindow ()
+  : mp_main_window (0)
+{
+  //  .. nothing yet ..
+}
+
+void
+PluginRootToMainWindow::attach_to (lay::MainWindow *main_window)
+{
+  mp_main_window = main_window;
+}
+
+void
+PluginRootToMainWindow::plugin_registered (lay::PluginDeclaration *cls)
+{
+  if (mp_main_window.get ()) {
+    mp_main_window->plugin_registered (cls);
   }
 
   //  re-establish the configuration
   config_setup ();
+}
+
+void
+PluginRootToMainWindow::plugin_removed (lay::PluginDeclaration *cls)
+{
+  if (mp_main_window.get ()) {
+    mp_main_window->plugin_removed (cls);
+  }
+
+  //  re-establish the configuration
+  config_setup ();
+}
+
+void
+PluginRootToMainWindow::select_mode (int mode)
+{
+  if (mp_main_window.get ()) {
+    mp_main_window->select_mode (mode);
+  }
+}
+
+void
+PluginRootToMainWindow::menu_activated (const std::string &symbol)
+{
+  if (mp_main_window.get ()) {
+    mp_main_window->menu_activated (symbol);
+  }
+}
+
+bool
+PluginRootToMainWindow::configure (const std::string &name, const std::string &value)
+{
+  if (mp_main_window.get ()) {
+    return mp_main_window->configure (name, value);
+  } else {
+    return false;
+  }
+}
+
+void
+PluginRootToMainWindow::config_finalize ()
+{
+  if (mp_main_window.get ()) {
+    mp_main_window->config_finalize ();
+  }
 }
 
 // ------------------------------------------------------------

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -120,8 +120,8 @@ private:
 
 class LAY_PUBLIC MainWindow
   : public QMainWindow,
-    public lay::AbstractMenuProvider,
-    public lay::PluginRoot
+    public tl::Object,
+    public lay::AbstractMenuProvider
 {
 Q_OBJECT
 public:
@@ -551,7 +551,7 @@ public:
   void show_macro_editor (const std::string &cat = std::string (), bool add = false);
 
   /**
-   *  @brief Reimplementation of the plugin interface: handle a generic menu request
+   *  @brief Handles a generic menu request
    */
   void menu_activated (const std::string &symbol);
 
@@ -870,6 +870,8 @@ protected:
   void do_update_file_menu ();
 
 private:
+  friend class PluginRootToMainWindow;
+
   TextProgressDelegate m_text_progress;
 
   //  Main menu
@@ -973,12 +975,34 @@ private:
   void update_dock_widget_state ();
   void read_dock_widget_state ();
 
-  virtual void plugin_registered (lay::PluginDeclaration *cls);
-  virtual void plugin_removed (lay::PluginDeclaration *cls);
+  void plugin_registered (lay::PluginDeclaration *cls);
+  void plugin_removed (lay::PluginDeclaration *cls);
 
   void libraries_changed ();
   void apply_key_bindings ();
   void apply_hidden (const std::vector<std::pair <std::string, bool> > &hidden);
+};
+
+class LAY_PUBLIC PluginRootToMainWindow
+  : public lay::PluginRoot
+{
+public:
+  PluginRootToMainWindow ();
+
+  void attach_to (lay::MainWindow *main_window);
+
+  virtual void plugin_registered (lay::PluginDeclaration *cls);
+  virtual void plugin_removed (lay::PluginDeclaration *cls);
+  virtual void select_mode (int mode);
+  virtual void menu_activated (const std::string &symbol);
+  virtual bool configure (const std::string &name, const std::string &value);
+  virtual void config_finalize ();
+
+private:
+  PluginRootToMainWindow (const PluginRootToMainWindow &);
+  PluginRootToMainWindow &operator= (const PluginRootToMainWindow &);
+
+  tl::weak_ptr<MainWindow> mp_main_window;
 };
 
 }

--- a/src/lay/lay/layNavigator.cc
+++ b/src/lay/lay/layNavigator.cc
@@ -447,7 +447,7 @@ Navigator::Navigator (MainWindow *main_window)
   mp_menu_bar->setFrameShape (QFrame::NoFrame);
   mp_menu_bar->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-  mp_view = new LayoutView (0, false, mp_main_window, this, "navigator", LayoutView::LV_Naked + LayoutView::LV_NoZoom + LayoutView::LV_NoServices + LayoutView::LV_NoGrid);
+  mp_view = new LayoutView (0, false, lay::PluginRoot::instance (), this, "navigator", LayoutView::LV_Naked + LayoutView::LV_NoZoom + LayoutView::LV_NoServices + LayoutView::LV_NoGrid);
   mp_view->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Expanding);
   mp_view->setMinimumWidth (100);
   mp_view->setMinimumHeight (100);
@@ -586,8 +586,8 @@ Navigator::showEvent (QShowEvent *)
 void 
 Navigator::closeEvent (QCloseEvent *)
 {
-  mp_main_window->config_set (cfg_show_navigator, "false");
-  mp_main_window->config_finalize ();
+  lay::PluginRoot::instance ()->config_set (cfg_show_navigator, "false");
+  lay::PluginRoot::instance ()->config_end ();
 }
 
 void 

--- a/src/lay/lay/laySaltController.cc
+++ b/src/lay/lay/laySaltController.cc
@@ -128,11 +128,9 @@ SaltController::show_editor ()
 
   if (mp_salt_dialog) {
 
-    if (mp_mw) {
-      std::string s = mp_mw->config_get (cfg_salt_manager_window_state);
-      if (! s.empty ()) {
-        lay::restore_dialog_state (mp_salt_dialog, s);
-      }
+    std::string s = lay::PluginRoot::instance ()->config_get (cfg_salt_manager_window_state);
+    if (! s.empty ()) {
+      lay::restore_dialog_state (mp_salt_dialog, s);
     }
 
     //  while running the dialog, don't watch file events - that would interfere with
@@ -141,9 +139,7 @@ SaltController::show_editor ()
     mp_salt_dialog->exec ();
     m_file_watcher->enable (true);
 
-    if (mp_mw) {
-      mp_mw->config_set (cfg_salt_manager_window_state, lay::save_dialog_state (mp_salt_dialog));
-    }
+    lay::PluginRoot::instance ()->config_set (cfg_salt_manager_window_state, lay::save_dialog_state (mp_salt_dialog));
 
     sync_file_watcher ();
 

--- a/src/lay/lay/laySettingsForm.cc
+++ b/src/lay/lay/laySettingsForm.cc
@@ -40,9 +40,9 @@ namespace lay
 
 // -------------------------------------------------------------
 
-SettingsForm::SettingsForm (QWidget *parent, lay::MainWindow *mw, const char *name)
+SettingsForm::SettingsForm (QWidget *parent, lay::PluginRoot *plugin_root, const char *name)
   : QDialog (parent), Ui::SettingsForm (),
-    mp_main_window (mw), m_finalize_recursion (false)
+    mp_plugin_root (plugin_root), m_finalize_recursion (false)
 { 
   setObjectName (QString::fromUtf8 (name));
 
@@ -237,7 +237,7 @@ SettingsForm::setup ()
 
   //  setup the custom config pages
   for (std::vector <lay::ConfigPage *>::iterator cp = m_config_pages.begin (); cp != m_config_pages.end (); ++cp) {
-    (*cp)->setup (mp_main_window);
+    (*cp)->setup (mp_plugin_root);
   }
 }
 
@@ -246,14 +246,14 @@ SettingsForm::commit () throw (tl::Exception)
 {
   //  commit the custom config pages
   for (std::vector <lay::ConfigPage *>::iterator cp = m_config_pages.begin (); cp != m_config_pages.end (); ++cp) {
-    (*cp)->commit (mp_main_window);
+    (*cp)->commit (mp_plugin_root);
   }
 
   m_finalize_recursion = true;
   try {
     //  config_end will make the main window call setup on the settings form. 
     //  the recursion sentinel takes care of that.
-    mp_main_window->config_end ();
+    mp_plugin_root->config_end ();
     m_finalize_recursion = false;
   } catch (...) {
     m_finalize_recursion = false;

--- a/src/lay/lay/laySettingsForm.h
+++ b/src/lay/lay/laySettingsForm.h
@@ -37,7 +37,7 @@
 namespace lay
 {
 
-class MainWindow;
+class PluginRoot;
 class ConfigPage;
 
 class SettingsForm
@@ -46,7 +46,7 @@ class SettingsForm
   Q_OBJECT
 
 public:
-  SettingsForm (QWidget *parent, lay::MainWindow *lv, const char *name);
+  SettingsForm (QWidget *parent, lay::PluginRoot *plugin_root, const char *name);
   
   void setup ();
   void commit () throw (tl::Exception);
@@ -58,7 +58,7 @@ public slots:
   void item_changed (QTreeWidgetItem *, QTreeWidgetItem *);
 
 private:
-  lay::MainWindow *mp_main_window;
+  lay::PluginRoot *mp_plugin_root;
   std::vector <lay::ConfigPage *> m_config_pages;
   bool m_finalize_recursion;
 };

--- a/src/lay/lay/layTechnologyController.cc
+++ b/src/lay/lay/layTechnologyController.cc
@@ -203,7 +203,7 @@ void
 TechnologyController::technologies_changed ()
 {
   //  update the configuration to reflect the persisted technologies
-  lay::PluginRoot *pr = mp_mw;
+  lay::PluginRoot *pr = lay::PluginRoot::instance ();
   if (pr) {
     m_configure_enabled = false;
     try {
@@ -474,9 +474,7 @@ TechnologyController::show_editor ()
 
   }
 
-  if (mp_mw) {
-    mp_mw->config_set (cfg_tech_editor_window_state, lay::save_dialog_state (mp_editor));
-  }
+  lay::PluginRoot::instance ()->config_set (cfg_tech_editor_window_state, lay::save_dialog_state (mp_editor));
 }
 
 const std::string &

--- a/src/laybasic/laybasic/gsiDeclLayPlugin.cc
+++ b/src/laybasic/laybasic/gsiDeclLayPlugin.cc
@@ -851,16 +851,26 @@ Class<gsi::ButtonStateNamespace> decl_ButtonState ("ButtonState",
 );
 
 static std::vector<std::string> 
-get_config_names (lay::PluginRoot *view)
+get_config_names (lay::PluginRoot *root)
 {
   std::vector<std::string> names;
-  view->get_config_names (names);
+  root->get_config_names (names);
   return names;
 }
 
-lay::PluginRoot *config_root_instance ()
+static lay::PluginRoot *config_root_instance ()
 {
   return lay::PluginRoot::instance ();
+}
+
+static tl::Variant get_config (lay::PluginRoot *root, const std::string &name)
+{
+  std::string value;
+  if (root->config_get (name, value)) {
+    return tl::Variant (value);
+  } else {
+    return tl::Variant ();
+  }
 }
 
 /**
@@ -870,7 +880,7 @@ lay::PluginRoot *config_root_instance ()
  *  identify the plugin root node for configuration. The Plugin nature of this interface
  *  is somewhat artificial and may be removed later. 
  *
- *  TODO: this is a duplicate of the respective methods in LayoutView and MainWindow.
+ *  TODO: this is a duplicate of the respective methods in LayoutView and Application.
  *  This is intentional since we don't want to spend the only derivation path on this.
  *  Once there is a mixin concept, provide a path through that concept.
  */
@@ -900,13 +910,13 @@ Class<lay::PluginRoot> decl_PluginRoot ("PluginRoot",
     "exist. If it does and an error occured, the error message is printed\n"
     "on stderr. In both cases, false is returned.\n"
   ) +
-  method ("get_config", (bool (lay::PluginRoot::*) (const std::string &, std::string &) const) &lay::PluginRoot::config_get,
-    "@brief Get the value of a local configuration parameter\n"
+  method_ext ("get_config", &get_config,
+    "@brief Gets the value of a local configuration parameter\n"
     "\n"
     "@args name\n"
     "@param name The name of the configuration parameter whose value shall be obtained (a string)\n"
     "\n"
-    "@return The value of the parameter\n"
+    "@return The value of the parameter or nil if there is no such parameter\n"
   ) +
   method ("set_config", (void (lay::PluginRoot::*) (const std::string &, const std::string &)) &lay::PluginRoot::config_set,
     "@brief Set a local configuration parameter with the given name to the given value\n"
@@ -938,11 +948,16 @@ Class<lay::PluginRoot> decl_PluginRoot ("PluginRoot",
   ),
   "@brief Root of the configuration space in the plugin context\n"
   "\n"
-  "This class provides access to the root configuration space. This object provides access to the configuration space in the context "
-  "of plugin programming.\n"
-  "Plugins are organized in a configuration tree. Configuration settings are propagated down to the individual plugins. "
-  "If there is a main window, the configuration root is identical with this object, so configuration settings "
-  "applied in the configuration root are available to all views.\n"
+  "This class provides access to the root configuration space in the context "
+  "of plugin programming. You can use this class to obtain configuration parameters "
+  "from the configuration tree during plugin initialization. However, the "
+  "preferred way of plugin configuration is through \\Plugin#configure.\n"
+  "\n"
+  "Currently, the application object provides an identical entry point for configuration modification. "
+  "For example, \"Application::instance.set_config\" is identical to \"PluginRoot::instance.set_config\". "
+  "Hence there is little motivation for the PluginRoot class currently and "
+  "this interface may be modified or removed in the future."
+  "\n"
   "\n"
   "This class has been introduced in version 0.25.\n"
 );


### PR DESCRIPTION
The solution consists of separating the PluginRoot
interface from the MainWindow. As there is a
singleton getter (PluginRoot::instance) this isn't
really required and the MainWindow - PluginRoot identity
is artificial anyway: the Ruby/Python API identifies
the application with the PluginRoot. This is the better
solution as MainWindow is only available in GUI-mode
applications.