### PR TITLE
Config cleanup

### DIFF
--- a/src/ant/ant/antPlugin.cc
+++ b/src/ant/ant/antPlugin.cc
@@ -169,7 +169,7 @@ PluginDeclaration::config_finalize ()
 }
 
 void 
-PluginDeclaration::initialized (lay::PluginRoot *)
+PluginDeclaration::initialized (lay::PluginRoot *root)
 {
   //  Check if we already have templates (initial setup)
   bool any_templates = false;
@@ -198,8 +198,8 @@ PluginDeclaration::initialized (lay::PluginRoot *)
 
     m_templates.push_back (ant::Template (tl::to_string (QObject::tr ("Box")), "W=$(abs(X))", "H=$(abs(Y))", "", ant::Object::STY_line, ant::Object::OL_box, true, lay::AC_Global, std::string ()));
 
-    lay::PluginRoot::instance ()->config_set (cfg_ruler_templates, ant::TemplatesConverter ().to_string (m_templates));
-    lay::PluginRoot::instance ()->config_end ();
+    root->config_set (cfg_ruler_templates, ant::TemplatesConverter ().to_string (m_templates));
+    root->config_end ();
 
   }
 }

--- a/src/lay/lay/layMainWindow.h
+++ b/src/lay/lay/layMainWindow.h
@@ -134,7 +134,7 @@ public:
   /**
    *  @brief Constructor
    */
-  MainWindow (QApplication *app = 0, lay::PluginRoot *plugin_root = 0, const char *name = "main_window");
+  MainWindow (QApplication *app = 0, lay::Plugin *parent_plugin = 0, const char *name = "main_window");
 
   /** 
    *  @brief Destructor
@@ -872,7 +872,6 @@ protected:
 private:
   friend class PluginRootToMainWindow;
 
-  lay::PluginRoot *mp_plugin_root;
   TextProgressDelegate m_text_progress;
 
   //  Main menu

--- a/src/lay/lay/layNavigator.h
+++ b/src/lay/lay/layNavigator.h
@@ -83,13 +83,13 @@ public:
   void freeze_clicked (); 
   void all_hier_levels (bool f);
   void show_images (bool f);
-  void background_color (QColor c);
 
   static void init_menu (AbstractMenu &menu);
 
 protected:
   virtual void closeEvent (QCloseEvent *event);
   virtual void showEvent (QShowEvent *event);
+  virtual void resizeEvent (QResizeEvent *event);
 
 private slots:
   void menu_changed ();

--- a/src/lay/lay/layNavigator.h
+++ b/src/lay/lay/layNavigator.h
@@ -121,6 +121,7 @@ private:
   void layers_changed (int);
   void viewport_changed ();
   void hier_levels_changed ();
+  void update_background_color ();
 
   void content_changed_with_int (int)
   {

--- a/src/laybasic/laybasic/layLayoutView.cc
+++ b/src/laybasic/laybasic/layLayoutView.cc
@@ -247,16 +247,16 @@ const int timer_interval = 500;
 
 static LayoutView *ms_current = 0;
 
-LayoutView::LayoutView (db::Manager *manager, bool editable, lay::PluginRoot *root, QWidget *parent, const char *name, unsigned int options)
+LayoutView::LayoutView (db::Manager *manager, bool editable, lay::Plugin *plugin_parent, QWidget *parent, const char *name, unsigned int options)
   : QFrame (parent), 
-    lay::Plugin (root),
+    lay::Plugin (plugin_parent),
     m_editable (editable),
     m_options (options),
     m_annotation_shapes (manager),
     dm_prop_changed (this, &LayoutView::do_prop_changed) 
 {
   setObjectName (QString::fromUtf8 (name));
-  init (manager, root, parent);
+  init (manager, plugin_root (), parent);
 }
 
 LayoutView::LayoutView (lay::LayoutView *source, db::Manager *manager, bool editable, lay::PluginRoot *root, QWidget *parent, const char *name, unsigned int options)
@@ -271,7 +271,7 @@ LayoutView::LayoutView (lay::LayoutView *source, db::Manager *manager, bool edit
 
   m_annotation_shapes = source->m_annotation_shapes;
 
-  init (manager, root, parent);
+  init (manager, plugin_root (), parent);
 
   //  set the handle reference and clear all cell related stuff 
   m_cellviews = source->cellview_list ();
@@ -4462,6 +4462,8 @@ LayoutView::background_color (QColor c)
   mp_canvas->set_colors (c, contrast, mp_canvas->active_color ());
 
   update_content ();
+
+  background_color_changed_event ();
 }
 
 void 

--- a/src/laybasic/laybasic/layLayoutView.h
+++ b/src/laybasic/laybasic/layLayoutView.h
@@ -182,7 +182,7 @@ public:
   /**
    *  @brief Constructor
    */
-  LayoutView (db::Manager *mgr, bool editable, lay::PluginRoot *root, QWidget *parent = 0, const char *name = "view", unsigned int options = (unsigned int) LV_Normal);
+  LayoutView (db::Manager *mgr, bool editable, lay::Plugin *plugin_parent, QWidget *parent = 0, const char *name = "view", unsigned int options = (unsigned int) LV_Normal);
 
   /**
    *  @brief Constructor (clone from another view)
@@ -650,6 +650,11 @@ public:
    *  is triggered.
    */
   tl::Event viewport_changed_event;
+
+  /**
+   *  @brief This event is triggered if the background color changed
+   */
+  tl::Event background_color_changed_event;
 
   /**
    *  @brief An event signalling that the layer list has changed.

--- a/src/laybasic/laybasic/layPlugin.h
+++ b/src/laybasic/laybasic/layPlugin.h
@@ -532,7 +532,8 @@ public:
    *
    *  In order to make configuration changes effective, this method
    *  must be called. It calls config_finalize recursively on the 
-   *  children.
+   *  children. In GUI-enabled applications this step is optional
+   *  and is performed automatically through a timer.
    */
   void config_end ();
 
@@ -631,6 +632,12 @@ public:
    *  @brief Get the names of all configuration options available
    */
   void get_config_names (std::vector<std::string> &names) const;
+
+  /**
+   *  @brief Gets the plugin root (the parent plugin not having another parent)
+   *  The returned pointer is guaranteed to be non-zero.
+   */
+  PluginRoot *plugin_root ();
 
   /**
    *  @brief Menu command handler
@@ -761,7 +768,7 @@ private:
   /**
    *  @brief Do the actual set or pass to the children if not taken 
    */
-  bool do_config_set (const std::string &name, const std::string &value);
+  bool do_config_set (const std::string &name, const std::string &value, bool for_child);
 
   /**
    *  @brief Recursively call config_finalize


### PR DESCRIPTION
This commit tries to fix the following issue: Configuring a single view behaves strangely:

```
pya.Application.instance().set_config("background-color", "#707070")  # OK
pya.LayoutView.current().set_config("background-color", "#7070FF")  # OK
pya.Application.instance().set_config("background-color", "#000000")  # OK
pya.LayoutView.current().set_config("background-color", "#7070FF")  # DOES NOTHING !

# but:
pya.LayoutView.current().set_config("background-color", "#000000")
pya.LayoutView.current().set_config("background-color", "#7070FF")  # OK
```
It looks like #7070FF is kept, although overridden by #000000 from application. 
changing to #7070FF doesn't change it, hence does not have an effect.

There is one more small issue: the navigator did not modify it's background when the view's background was modified.