### PR TITLE
Azure/windows wheel builds Py 3.5,3.6,3.7 win32 and win64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,12 @@ jobs:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
-      # Python35:
-      #   python.version: '3.5'
-      # Python36:
-      #   python.version: '3.6'
+      # Python27:
+      #   python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
     maxParallel: 3
 
   steps:
@@ -40,14 +40,14 @@ jobs:
       #workingDirectory: # Optional
     displayName: 'Downloading and Extracting KLayout bits'
 
-  - script: |
-      curl https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -o VCForPython27.msi
-      msiexec /i VCForPython27.msi /quiet
-      set "VS90COMNTOOLS=C:\Users\VssAdministrator\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC"
-      curl https://raw.githubusercontent.com/mattn/gntp-send/master/include/msinttypes/stdint.h -o "%VS90COMNTOOLS%\Include\stdint.h"
-      dir "%VS90COMNTOOLS%\Include"
-    condition: eq(variables['python.version'], '2.7')
-    displayName: 'Installing Microsoft Visual C++ Compiler for Python 2.7'
+  # - script: |
+  #     curl https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -o VCForPython27.msi
+  #     msiexec /i VCForPython27.msi /quiet
+  #     set "VS90COMNTOOLS=C:\Users\VssAdministrator\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC"
+  #     curl https://raw.githubusercontent.com/mattn/gntp-send/master/include/msinttypes/stdint.h -o "%VS90COMNTOOLS%\Include\stdint.h"
+  #     dir "%VS90COMNTOOLS%\Include"
+  #   condition: eq(variables['python.version'], '2.7')
+  #   displayName: 'Installing Microsoft Visual C++ Compiler for Python 2.7'
 
   - script: |
       pip install --user --upgrade pip setuptools wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
       #ignoreLASTEXITCODE: false # Optional
       #pwsh: false # Optional
       #workingDirectory: # Optional
-    displayName: 'Downloading and Extracting KLayout bits'
+    displayName: 'Download and Extract KLayout bits'
 
   # - script: |
   #     curl https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -o VCForPython27.msi
@@ -61,28 +61,28 @@ jobs:
   #     curl https://raw.githubusercontent.com/mattn/gntp-send/master/include/msinttypes/stdint.h -o "%VS90COMNTOOLS%\Include\stdint.h"
   #     dir "%VS90COMNTOOLS%\Include"
   #   condition: eq(variables['python.version'], '2.7')
-  #   displayName: 'Installing Microsoft Visual C++ Compiler for Python 2.7'
+  #   displayName: 'Install Microsoft Visual C++ Compiler for Python 2.7'
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-    displayName: 'Updating pip, setuptools and wheel'
+    displayName: 'Update pip, setuptools and wheel'
 
   - script: |
       python -V
       set "KLAYOUT_BITS=%cd%\klayout-microbits\klayout-microbits-1.0\msvc2017\%PYTHON_ARCHITECTURE%"
       echo KLAYOUT_BITS=%KLAYOUT_BITS%
-      python setup.py install
+      python setup.py bdist_wheel
     displayName: 'Build KLayout'
 
+  - bash: |
+      bash `pwd`/ci-scripts/windows/fix_wheel.sh `pwd`/dist/*.whl "`pwd`/klayout-microbits/klayout-microbits-1.0/msvc2017/$PYTHON_ARCHITECTURE"
+    displayName: 'Copy klayout bits dlls into wheel'
+
   - script: |
-      set PATH=%KLAYOUT_BITS%\curl\bin;%KLAYOUT_BITS%\expat\bin;%KLAYOUT_BITS%\ptw\bin;%KLAYOUT_BITS%\zlib\bin;%PATH%
+      echo PATH=%PATH%
+      pip install klayout --no-index -f dist
       python testdata/pymod/import_db.py
       python testdata/pymod/import_rdb.py
       python testdata/pymod/import_tl.py
       python testdata/pymod/pya_tests.py
     displayName: 'Test KLayout pymod'
-
-  # - script : |
-  #     python setup.py bdist_wheel
-  #   displayName: 'Building KLayout wheel'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,4 +98,4 @@ jobs:
     condition: always()
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: drop
+      artifactName: 'wheel-$(python.version).$(python.architecture)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,17 +9,29 @@ jobs:
       #   python.version: '2.7'
       Python35:
         python.version: '3.5'
+        python.architecture: 'x64'
       Python36:
         python.version: '3.6'
+        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
-    maxParallel: 3
+        python.architecture: 'x64'
+      Python35_x86:
+        python.version: '3.5'
+        python.architecture: 'x86'
+      Python36_x86:
+        python.version: '3.6'
+        python.architecture: 'x86'
+      Python37_x86:
+        python.version: '3.7'
+        python.architecture: 'x86'
+    maxParallel: 6
 
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
-      architecture: 'x64'
+      architecture: '$(python.architecture)'
 
   # Add additional tasks to run using each Python version in the matrix above
 
@@ -52,12 +64,13 @@ jobs:
   #   displayName: 'Installing Microsoft Visual C++ Compiler for Python 2.7'
 
   - script: |
-      pip install --user --upgrade pip setuptools wheel
+      python -m pip install --upgrade pip setuptools wheel
     displayName: 'Updating pip, setuptools and wheel'
 
   - script: |
       python -V
-      set "KLAYOUT_BITS=%cd%\klayout-microbits\klayout-microbits-1.0\msvc2017\x64"
+      set "KLAYOUT_BITS=%cd%\klayout-microbits\klayout-microbits-1.0\msvc2017\%PYTHON_ARCHITECTURE%"
+      echo KLAYOUT_BITS=%KLAYOUT_BITS%
       python setup.py install
 
     displayName: 'Building KLayout'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,47 @@
+# https://aka.ms/yaml
+jobs:
+- job: 'Test'
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+    maxParallel: 3
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  # Add additional tasks to run using each Python version in the matrix above
+
+  # PowerShell
+  # Run a PowerShell script on Windows, macOS, or Linux.
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline' # Optional. Options: filePath, inline
+      #filePath: # Required when targetType == FilePath
+      #arguments: # Optional
+      script: | # Required when targetType == Inline
+        pwd
+        dir
+        Invoke-WebRequest -Uri "https://www.dropbox.com/s/ioax2mnic4987kn/klayout-microbits-1.0.zip?dl=1" -MaximumRedirection 2 -OutFile klayout-microbits-1.0.zip
+        Expand-Archive klayout-microbits-1.0.zip -DestinationPath klayout-microbits
+        dir klayout-microbits
+      #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
+      #failOnStderr: false # Optional
+      #ignoreLASTEXITCODE: false # Optional
+      #pwsh: false # Optional
+      #workingDirectory: # Optional
+    displayName: 'Downloading and Extracting KLayout bits'
+
+  - script: |
+      python -V
+      pwd
+    displayName: 'Diagnostic information'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,28 +1,28 @@
 # https://aka.ms/yaml
 jobs:
-- job: 'Build'
+- job: Build
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
   strategy:
     matrix:
       # Python27:
       #   python.version: '2.7'
-      Python35:
+      cp35-cp35m-win_amd64.whl:
         python.version: '3.5'
         python.architecture: 'x64'
-      Python36:
+      cp36-cp36m-win_amd64.whl:
         python.version: '3.6'
         python.architecture: 'x64'
-      Python37:
+      cp37-cp37m-win_amd64.whl:
         python.version: '3.7'
         python.architecture: 'x64'
-      Python35_x86:
+      cp35-cp35m-win32.whl:
         python.version: '3.5'
         python.architecture: 'x86'
-      Python36_x86:
+      cp36-cp36m-win32.whl:
         python.version: '3.6'
         python.architecture: 'x86'
-      Python37_x86:
+      cp37-cp37m-win32.whl:
         python.version: '3.7'
         python.architecture: 'x86'
     maxParallel: 6
@@ -99,3 +99,54 @@ jobs:
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'wheel-$(python.version).$(python.architecture)'
+
+- job: 'Deploy'
+  displayName: 'Combine Windows wheels'
+  dependsOn: Build
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  steps:
+    - checkout: none #skip checking out the default repository resource
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.7.x64'
+      inputs:
+        artifactName: 'wheel-3.7.x64'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.6.x64'
+      inputs:
+        artifactName: 'wheel-3.6.x64'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.5.x64'
+      inputs:
+        artifactName: 'wheel-3.5.x64'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.7.x86'
+      inputs:
+        artifactName: 'wheel-3.7.x86'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.6.x86'
+      inputs:
+        artifactName: 'wheel-3.6.x86'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Build Artifacts wheel-3.5.x86'
+      inputs:
+        artifactName: 'wheel-3.5.x86'
+        downloadPath: '$(System.DefaultWorkingDirectory)'
+    - task: CopyFiles@2
+      condition: always()
+      inputs:
+        sourceFolder: '$(System.DefaultWorkingDirectory)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+        contents: '**/?(*.whl)'
+        flattenFolders: true
+    - task: PublishBuildArtifacts@1
+      condition: always()
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: 'windows_wheels'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       #arguments: # Optional
       script: | # Required when targetType == Inline
         pwd
-        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -OutFile klayout-microbits-1.0.beta.zip
+        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -OutFile klayout-microbits-1.0.zip
         dir
         Expand-Archive klayout-microbits-1.0.zip -DestinationPath klayout-microbits
         dir klayout-microbits

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ jobs:
         python.version: '3.5'
       Python36:
         python.version: '3.6'
+      Python37:
+        python.version: '3.7'
     maxParallel: 3
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,16 +1,16 @@
 # https://aka.ms/yaml
 jobs:
-- job: 'Test'
+- job: 'Build'
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
   strategy:
     matrix:
       Python27:
         python.version: '2.7'
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
+      # Python35:
+      #   python.version: '3.5'
+      # Python36:
+      #   python.version: '3.6'
     maxParallel: 3
 
   steps:
@@ -26,7 +26,6 @@ jobs:
   - task: PowerShell@2
     inputs:
       targetType: 'inline' # Optional. Options: filePath, inline
-      #filePath: # Required when targetType == FilePath
       #arguments: # Optional
       script: | # Required when targetType == Inline
         pwd
@@ -40,6 +39,15 @@ jobs:
       #pwsh: false # Optional
       #workingDirectory: # Optional
     displayName: 'Downloading and Extracting KLayout bits'
+
+  - script: |
+      curl https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -o VCForPython27.msi
+      msiexec /i VCForPython27.msi /quiet
+      set "VS90COMNTOOLS=C:\Users\VssAdministrator\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC"
+      curl https://raw.githubusercontent.com/mattn/gntp-send/master/include/msinttypes/stdint.h -o "%VS90COMNTOOLS%\Include\stdint.h"
+      dir "%VS90COMNTOOLS%\Include"
+    condition: eq(variables['python.version'], '2.7')
+    displayName: 'Installing Microsoft Visual C++ Compiler for Python 2.7'
 
   - script: |
       pip install --user --upgrade pip setuptools wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
       script: | # Required when targetType == Inline
         pwd
         dir
-        Invoke-WebRequest -Uri "https://www.dropbox.com/s/ioax2mnic4987kn/klayout-microbits-1.0.zip?dl=1" -MaximumRedirection 2 -OutFile klayout-microbits-1.0.zip
+        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -MaximumRedirection 2 -OutFile klayout-microbits-1.0.beta.zip
         Expand-Archive klayout-microbits-1.0.zip -DestinationPath klayout-microbits
         dir klayout-microbits
       #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,5 +72,17 @@ jobs:
       set "KLAYOUT_BITS=%cd%\klayout-microbits\klayout-microbits-1.0\msvc2017\%PYTHON_ARCHITECTURE%"
       echo KLAYOUT_BITS=%KLAYOUT_BITS%
       python setup.py install
+    displayName: 'Build KLayout'
 
-    displayName: 'Building KLayout'
+  - script: |
+      set PATH=%KLAYOUT_BITS%\curl\bin;%KLAYOUT_BITS%\expat\bin;%KLAYOUT_BITS%\ptw\bin;%KLAYOUT_BITS%\zlib\bin;%PATH%
+      python testdata/pymod/import_db.py
+      python testdata/pymod/import_rdb.py
+      python testdata/pymod/import_tl.py
+      python testdata/pymod/pya_tests.py
+    displayName: 'Test KLayout pymod'
+
+  # - script : |
+  #     python setup.py bdist_wheel
+  #   displayName: 'Building KLayout wheel'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       #arguments: # Optional
       script: | # Required when targetType == Inline
         pwd
-        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -OutFile klayout-microbits-1.0.zip
+        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.zip" -OutFile klayout-microbits-1.0.zip
         dir
         Expand-Archive klayout-microbits-1.0.zip -DestinationPath klayout-microbits
         dir klayout-microbits

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,12 @@ jobs:
     displayName: 'Downloading and Extracting KLayout bits'
 
   - script: |
+      pip install --user --upgrade pip setuptools wheel
+    displayName: 'Updating pip, setuptools and wheel'
+
+  - script: |
       python -V
-      pwd
-    displayName: 'Diagnostic information'
+      set "KLAYOUT_BITS=%cd%\klayout-microbits\klayout-microbits-1.0\msvc2017\x64"
+      python setup.py install
+
+    displayName: 'Building KLayout'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,8 @@ jobs:
       #arguments: # Optional
       script: | # Required when targetType == Inline
         pwd
+        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -OutFile klayout-microbits-1.0.beta.zip
         dir
-        Invoke-WebRequest -Uri "https://dl.bintray.com/lightwave-lab/klayout/klayout-microbits-1.0.beta.zip" -MaximumRedirection 2 -OutFile klayout-microbits-1.0.beta.zip
         Expand-Archive klayout-microbits-1.0.zip -DestinationPath klayout-microbits
         dir klayout-microbits
       #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,3 +86,16 @@ jobs:
       python testdata/pymod/import_tl.py
       python testdata/pymod/pya_tests.py
     displayName: 'Test KLayout pymod'
+
+  - task: CopyFiles@2
+    condition: always()
+    inputs:
+      sourceFolder: '$(Build.SourcesDirectory)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+      contents: '**/?(*.whl)'
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: drop

--- a/ci-scripts/windows/fix_wheel.sh
+++ b/ci-scripts/windows/fix_wheel.sh
@@ -75,9 +75,9 @@ cp -v $KLAYOUT_BITS/zlib/bin/* .
 #     exit 1
 # fi
 cd $TMP_WHEEL
-touch $TMP_WHEEL/patch_external_libraries_included
+# touch $TMP_WHEEL/patch_external_libraries_included
 echo "Packing $WHL from $TMP_WHEEL"
-# rm -f $WHL
+rm -f $WHL
 wheel pack $TMP_WHEEL -d `dirname $WHL` || exit 1
 echo "Done. $(basename $WHL) is patched."
 # Cleanup (should always execute)

--- a/ci-scripts/windows/fix_wheel.sh
+++ b/ci-scripts/windows/fix_wheel.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+SCRIPT_NAME=`basename "$0"`
+TMP_WHEEL="$PWD/tmp/klayout_tempwheel"
+
+display_usage() { 
+    echo "This script includes external libraries in windows-based wheels."
+    echo "Caution: This will delete the original wheel." 
+    echo -e "\nUsage:\n./${SCRIPT_NAME} [--help|-h] klayout-...-win_amd64.whl \n" 
+    }
+
+if [[ ( $1 == "--help") || $1 == "-h" ]] 
+then 
+    display_usage
+    exit 0
+fi
+
+# Check number of arguments
+if [ $# -eq 0 ]; then
+    >&2 echo -e "ERROR: No filename supplied\n"
+    display_usage
+    exit 1
+elif [ ! $# -eq 2 ]; then
+    >&2 echo -e "ERROR: Too many files supplied. Provide one filename at at time.\n"
+    display_usage
+    exit 1
+fi
+
+# Read wheel file from argument
+WHL="$1"
+WHL=$(echo $WHL | sed 's/\\/\//g' | sed 's/://')
+KLAYOUT_BITS="$2"
+KLAYOUT_BITS=$(echo $KLAYOUT_BITS | sed 's/\\/\//g' | sed 's/://')
+
+
+# Check WHL is a valid file
+if [[ ! -f "$WHL" ]]; then
+    >&2 echo -e "ERROR: $WHL is not a file"
+    exit 1
+fi
+
+# Convert to absolute path (linux only)
+WHL=$(readlink -f $WHL)
+
+# Record old current directory
+OLD_PWD=$PWD
+
+# Need to include external DLLs (klayout bits) into wheel
+
+# # Checking if it was previously patched
+# if unzip -l $WHL | grep -q 'patch_external_libraries_included'; then
+#     echo "$(basename $WHL) is already patched. Doing nothing."
+#     exit 0
+# fi
+
+# Repair script below
+if [[ -d $TMP_WHEEL ]]; then
+    rm -rf $TMP_WHEEL
+else
+    mkdir -p $TMP_WHEEL
+fi
+echo "Unpacking $WHL inside $TMP_WHEEL"
+wheel unpack $WHL -d $TMP_WHEEL || exit 1
+TMP_WHEEL="$TMP_WHEEL/`ls $TMP_WHEEL`"
+
+cd $TMP_WHEEL/klayout
+echo "Copying libraries: libcurl.dll, expat.dll, pthreadVCE2.dll, zlib1.dll"
+echo pwd: `pwd`
+cp -v $KLAYOUT_BITS/curl/bin/* .
+cp -v $KLAYOUT_BITS/expat/bin/* .
+cp -v $KLAYOUT_BITS/ptw/bin/* .
+cp -v $KLAYOUT_BITS/zlib/bin/* .
+# if [ $? -ne 0 ]; then
+#     >&2 echo "ERROR: lib not found. Quitting."
+#     exit 1
+# fi
+cd $TMP_WHEEL
+touch $TMP_WHEEL/patch_external_libraries_included
+echo "Packing $WHL from $TMP_WHEEL"
+# rm -f $WHL
+wheel pack $TMP_WHEEL -d `dirname $WHL` || exit 1
+echo "Done. $(basename $WHL) is patched."
+# Cleanup (should always execute)
+cd $OLD_PWD


### PR DESCRIPTION
Closes #217 

## Contributions:

-  Now `pip install klayout` works for python >= 3.5 on windows!

- Building pip wheels for windows (including libcurl, expat, zlib and pthread DLLs). I had to manually patch the wheel after the build to place the DLLs in the klayout module folder. *Python versions 3.5, 3.6, 3.7*, using MSVC++ 14 in *both Win 32 and 64* architectures. 3.4 and below would require MSVC++ 10.0, but I haven't tested them.

- I uploaded all wheels to pypi under version 0.26.0-dev10, excepting cp36 x64, which was already there for some reason. See https://dev.azure.com/thomaslima/klayout/_build/results?buildId=50&view=results

Issue: I could not build a wheel for Python 2.7. It uses a very outdated C++ compiler (MSVC++ 9.0) and KLayout's source fails to compile. This is pretty much what happens: [log_10_22.zip](https://github.com/klayoutmatthias/klayout/files/2720232/log_10_22.zip) I am not sure it is worth providing python 2.7 support for windows. (Mac and Linux still ok though)

### Todo:

- [x] - Maybe build part of klayout-bits in azure as well for completeness. Right now I am using pre-built "klayout-microbits-1.0.zip" which originated from klayout-micro-1.0.zip, but without python and ruby which take up a lot of space. [klayout-microbits-1.0.zip](https://github.com/klayoutmatthias/klayout/files/2720246/klayout-microbits-1.0.zip)
- [x] - Release 0.26.0-dev11 because the cp36 dev10 version was uploaded without the external library patch.
- [x] - Figure out how to organize continuous deploy in conjunction with Travis (or should we move to azure entirely?)