### PR TITLE
adding classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -498,6 +498,17 @@ if __name__ == '__main__':
           long_description='TODO',
           author='Matthias Koefferlein',
           author_email='matthias@klayout.de',
+          classifiers=[
+              # Recommended classifiers
+              "Programming Language :: Python :: 2",
+              "Programming Language :: Python :: 3",
+              "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+              "Operating System :: MacOS :: MacOS X",
+              "Operating System :: Microsoft :: Windows",
+              "Operating System :: POSIX :: Linux",
+              # Optional classifiers
+              "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+          ],
           url='https://github.com/klayoutmatthias/klayout',
           packages=find_packages('src/pymod/distutils_src'),
           package_dir={'': 'src/pymod/distutils_src'},  # https://github.com/pypa/setuptools/issues/230


### PR DESCRIPTION
I read in the PyPI user manual it was recommended.

I also read about licenses and it seems that all klayout dependencies are more permissive than GPLv3, but we need to include reference to the original authors. We can choose to incorporate all source files from external library or download on the fly. But we must mention somewhere in an appropriate location that we use these software and mention who owns the copyright and the license.

This is relevant because GitHub is not the only place klayout's source code is distributed. A piece of it is distributed via pypi as well. And I believe the condition applies even if only dynamic libraries are used.